### PR TITLE
FBISCC-24: Add the query and question pages

### DIFF
--- a/apps/fbis-ccf/behaviours/set-question.js
+++ b/apps/fbis-ccf/behaviours/set-question.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const options = require('../fields/index').question.options;
+
+module.exports = superclass => class SetQuestion extends superclass {
+
+  getValues(req, res, next) {
+    return super.getValues(req, res, (err, values) => {
+      if (err) {
+        return next(err);
+      }
+
+      options.forEach(option => {
+        values[`is-${option}`] = values.question === option;
+      });
+
+      return next(null, values);
+    });
+  }
+
+};

--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -1,3 +1,26 @@
 'use strict';
 
-module.exports = {};
+module.exports = {
+  query: {
+    mixin: 'textarea',
+    validate: ['required', { type: 'maxlength', arguments: 500 }],
+  },
+  name: {
+    validate: ['required'],
+  },
+  email: {
+    validate: ['required', 'email'],
+  },
+  phone: {},
+  'application-number': {
+    validate: ['required'],
+  },
+  question: {
+    mixin: 'radio-group',
+    validate: ['required'],
+    options: ['id-check', 'status', 'account'],
+    legend: {
+      className: 'visuallyhidden'
+    }
+  },
+};

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const setLocation = require('./behaviours/set-location');
 const addLocationToBacklink = require('./behaviours/add-location-to-backlink');
+const setLocation = require('./behaviours/set-location');
+const setQuestion = require('./behaviours/set-question');
 const summaryPage = require('hof-behaviour-summary-page');
 
 module.exports = {
@@ -10,11 +11,16 @@ module.exports = {
   steps: {
     '/landing': {
       behaviours: [setLocation],
-      template: 'landing',
       next: '/question'
     },
     '/question': {
       behaviours: [addLocationToBacklink],
+      fields: ['question'],
+      next: '/query'
+    },
+    '/query': {
+      behaviours: [setQuestion],
+      fields: ['query', 'name', 'email', 'phone', 'application-number'],
       next: '/confirm'
     },
     '/confirm': {

--- a/apps/fbis-ccf/translations/src/en/buttons.json
+++ b/apps/fbis-ccf/translations/src/en/buttons.json
@@ -1,3 +1,5 @@
 {
-    "start": "Start"
+    "start": "Start",
+    "continue": "Submit",
+    "save": "Save and continue"
 }

--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -1,1 +1,33 @@
-{}
+{
+  "query": {
+    "label": "Give us a detailed description of the problem",
+    "hint": "Describe what you were doing when the problem happened and any error messages"
+  },
+  "name": {
+    "label": "Full name"
+  },
+  "email": {
+    "label": "Email address"
+  },
+  "phone": {
+    "label": "Phone number (optional)"
+  },
+  "application-number": {
+    "label": "Unique application number (UAN)",
+    "hint": "For example, 3434-0000-0000-0001"
+  },
+  "question": {
+    "legend": "What is your technical problem about?",
+    "options": {
+      "id-check": {
+        "label": "The 'ID check' app"
+      },
+      "status" : {
+        "label" : "Viewing or proving your immigration status"
+      },
+      "account" : {
+        "label": "Updating your immigration account details"
+      }
+    }
+  }
+}

--- a/apps/fbis-ccf/translations/src/en/pages.json
+++ b/apps/fbis-ccf/translations/src/en/pages.json
@@ -6,6 +6,13 @@
     }
   },
   "question": {
-    "header": "What is your question about?"
+    "header": "What is your technical problem about?"
+  },
+  "query": {
+    "header": {
+      "status": "Tell us about a problem viewing or proving your immigration status",
+      "account": "Tell us about a problem updating your immigration account details",
+      "id-check": "Tell us about a problem with the 'ID check' app"
+    }
   }
 }

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -1,0 +1,19 @@
+{
+  "query": {
+    "required": "Enter details of the problem",
+    "maxlength": "Summary must be 500 characters or fewer"
+  },
+  "name": {
+    "required": "Enter your full name"
+  },
+  "email": {
+    "required": "Enter your email address",
+    "email": "Enter a valid email address"
+  },
+  "application-number": {
+    "required": "Enter your unique application number (UAN)"
+  },
+  "question": {
+    "required": "Select what your technical problem is about"
+  }
+}

--- a/apps/fbis-ccf/views/landing.html
+++ b/apps/fbis-ccf/views/landing.html
@@ -8,6 +8,6 @@
         {{/values.in-UK}}
     {{/header}}
     {{$page-content}}
-        <button class="button" type="submit">{{#t}}buttons.start{{/t}}</button>
+        {{#input-submit}}start{{/input-submit}}
     {{/page-content}}
 {{/partials-page}}

--- a/apps/fbis-ccf/views/query.html
+++ b/apps/fbis-ccf/views/query.html
@@ -1,0 +1,27 @@
+{{<step}}
+    {{$header}}
+        {{#values.is-account}}
+            {{#t}}pages.query.header.account{{/t}}
+        {{/values.is-account}}
+
+        {{#values.is-status}}
+            {{#t}}pages.query.header.status{{/t}}
+        {{/values.is-status}}
+
+        {{#values.is-id-check}}
+            {{#t}}pages.query.header.id-check{{/t}}
+        {{/values.is-id-check}}
+    {{/header}}
+
+    {{$page-content}}
+        {{#textarea}}query{{/textarea}}
+        {{#input-text}}name{{/input-text}}
+        {{#input-text}}email{{/input-text}}
+        {{#input-text}}phone{{/input-text}}
+        {{^values.is-id-check}}
+            {{#input-text}}application-number{{/input-text}}
+        {{/values.is-id-check}}
+        {{#input-submit}}continue{{/input-submit}}
+    {{/page-content}}
+
+{{/step}}

--- a/apps/fbis-ccf/views/question.html
+++ b/apps/fbis-ccf/views/question.html
@@ -1,0 +1,8 @@
+{{<step}}
+    {{$page-content}}
+    {{#fields}}
+        {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}save{{/input-submit}}
+{{/page-content}}
+{{/step}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,4 +1,5 @@
 @import "$$theme";
+@import "custom";
 
 .phase-banner {
   @include phase-banner(beta);

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,0 +1,20 @@
+// Custom styling for overriding HOF defaults as required by designs
+
+#query {
+  height: 120px; // 6x default line-height for screens < 641px wide
+  width: 100%;
+}
+
+@media (min-width: 641px) {
+  #query {
+    height: 150px; // 6x default line-height for this screen width
+  }
+
+  #name, #email {
+    width: 80%;
+  }
+
+  #phone, #application-number {
+    width: 67%;
+  }
+}

--- a/test/add-location-to-backlin.spec.js
+++ b/test/add-location-to-backlin.spec.js
@@ -19,7 +19,7 @@ describe('Add location to backlink behaviour', () => {
     res = {};
   });
 
-  describe('getValues', () => {
+  describe('locals', () => {
 
     class Base {
       locals() {

--- a/test/set-question.spec.js
+++ b/test/set-question.spec.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const Behaviour = require('../apps/fbis-ccf/behaviours/set-question');
+
+describe('Set question behaviour', () => {
+
+  let SetQuestion;
+  let testInstance;
+  let superErr;
+  let superValues;
+  let nextStub;
+
+  describe('getValues', () => {
+
+    class Base {
+      getValues(req, res, callback) {
+        callback(superErr, superValues);
+      }
+    }
+
+    beforeEach(() => {
+      SetQuestion = Behaviour(Base);
+      testInstance = new SetQuestion();
+
+      nextStub = sinon.stub();
+    });
+
+    it('should set `is-account` flag true if user is having an issue updating immigration account', () => {
+      superErr = null;
+      superValues = { question: 'account' };
+
+      const expected = {
+        'is-account': true,
+        'is-id-check': false,
+        'is-status': false,
+        question: 'account'
+      };
+
+      testInstance.getValues({}, {}, nextStub);
+      expect(nextStub).to.have.been.calledOnceWith(null, expected);
+    });
+
+    it('should set `is-is-check` flag true if user is having an issue with ID check app', () => {
+      superErr = null;
+      superValues = { question: 'id-check' };
+
+      const expected = {
+        'is-account': false,
+        'is-id-check': true,
+        'is-status': false,
+        question: 'id-check'
+      };
+
+      testInstance.getValues({}, {}, nextStub);
+      expect(nextStub).to.have.been.calledOnceWith(null, expected);
+    });
+
+    it('should set `status` flag true if user is having an issue viewing or proving immigration status', () => {
+      superErr = null;
+      superValues = { question: 'status' };
+
+      const expected = {
+        'is-account': false,
+        'is-id-check': false,
+        'is-status': true,
+        question: 'status'
+      };
+
+      testInstance.getValues({}, {}, nextStub);
+      expect(nextStub).to.have.been.calledOnceWith(null, expected);
+    });
+
+    it('should pass the error to the next middleware if super.getValues returns an error', () => {
+      superErr = 'error';
+      testInstance.getValues({}, {}, nextStub);
+      expect(nextStub).to.have.been.calledOnceWith('error');
+    });
+
+  });
+
+});


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/FBISCC-24

* Also covers FBISCC-7/25/26
* Adds interim page for user to choose what their technical problem is about
* Adds query page with templating for correct headers and fields based on technical problem
* Does not include email or UAN validation, awaiting business requirements

## What?
Add query and question pages
## Why?
So that the user can select their technical problem and submit a query with the correct fields and content
## How?
Add query and question page templates in views directory. 'set-question' behaviour adds flags to values that are used by query template to load correct content and fields
## Testing?
Add tests in tests folder
## Screenshots (optional)

<img width="921" alt="Screenshot 2020-10-27 at 11 28 13" src="https://user-images.githubusercontent.com/61828376/97295794-b26a7d00-1847-11eb-9b8a-4663db277113.png">

<img width="838" alt="Screenshot 2020-10-27 at 11 28 46" src="https://user-images.githubusercontent.com/61828376/97295822-bbf3e500-1847-11eb-810c-7c7573adce01.png">

<img width="842" alt="Screenshot 2020-10-27 at 11 28 36" src="https://user-images.githubusercontent.com/61828376/97295832-be563f00-1847-11eb-906b-deed4e53de77.png">

<img width="972" alt="Screenshot 2020-10-27 at 11 28 25" src="https://user-images.githubusercontent.com/61828376/97295839-beeed580-1847-11eb-9439-b9a0e05d6c9e.png">

<img width="849" alt="Screenshot 2020-10-27 at 11 29 07" src="https://user-images.githubusercontent.com/61828376/97295850-c44c2000-1847-11eb-9cc9-9f8438446849.png">


## Anything Else?
Validation of email and UAN split into new tickets, awaiting business requirements. A ticket will also be created to spike an accessible approach to character limits.