### PR TITLE
FBISCC-33: Fork to collect representative's details if writing on behalf of someone else

### DIFF
--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -1,17 +1,27 @@
 'use strict';
 
 module.exports = {
+  identity: {
+    mixin: 'radio-group',
+    validate: ['required'],
+    options: ['no', 'yes']
+  },
+  'representative-name': {
+    validate: ['required']
+  },
+  'representative-phone': {},
+  organisation: {},
   query: {
     mixin: 'textarea',
     validate: ['required', { type: 'maxlength', arguments: 500 }],
   },
-  name: {
+  'applicant-name': {
     validate: ['required'],
   },
   email: {
     validate: ['required', 'email'],
   },
-  phone: {},
+  'applicant-phone': {},
   'application-number': {
     validate: ['required'],
   },
@@ -22,5 +32,5 @@ module.exports = {
     legend: {
       className: 'visuallyhidden'
     }
-  },
+  }
 };

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -16,11 +16,28 @@ module.exports = {
     '/question': {
       behaviours: [addLocationToBacklink],
       fields: ['question'],
+      template: 'save-and-continue',
+      next: '/identity'
+    },
+    '/identity': {
+      fields: ['identity'],
+      template: 'save-and-continue',
+      next: '/query',
+      forks: [{
+        target: '/details',
+        condition: {
+          field: 'identity',
+          value: 'yes'
+        }
+      }],
+    },
+    '/details': {
+      fields: ['representative-name', 'representative-phone', 'organisation'],
       next: '/query'
     },
     '/query': {
       behaviours: [setQuestion],
-      fields: ['query', 'name', 'email', 'phone', 'application-number'],
+      fields: ['query', 'applicant-name', 'email', 'applicant-phone', 'application-number'],
       next: '/confirm'
     },
     '/confirm': {

--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -1,19 +1,51 @@
 {
+  "details": {
+    "hint": "Details of the person filling out this form"
+  },
+  "representative-name": {
+    "label": "Full name"
+  },
+  "representative-phone": {
+    "label": "Your phone number (optional)"
+  },
+  "organisation": {
+    "label": "Your organisation's name (optional)"
+  },
   "query": {
     "label": "Give us a detailed description of the problem",
     "hint": "Describe what you were doing when the problem happened and any error messages"
   },
-  "name": {
-    "label": "Full name"
+  "applicant-name": {
+    "label": {
+      "identity": {
+        "no" : "Full name",
+        "yes": "Applicant's full name"
+      }
+    }
   },
   "email": {
-    "label": "Email address"
+    "label": {
+      "identity": {
+        "no" : "Email address",
+        "yes": "Applicant's email address"
+      }
+    }
   },
-  "phone": {
-    "label": "Phone number (optional)"
+  "applicant-phone": {
+    "label": {
+      "identity": {
+        "no" : "Phone number",
+        "yes": "Applicant's phone number"
+      }
+    }
   },
   "application-number": {
-    "label": "Unique application number (UAN)",
+    "label": {
+      "identity": {
+        "no" : "Unique application number (UAN)",
+        "yes": "Applicant's unique application number (UAN)"
+      }
+    },
     "hint": "For example, 3434-0000-0000-0001"
   },
   "question": {
@@ -27,6 +59,17 @@
       },
       "account" : {
         "label": "Updating your immigration account details"
+      }
+    }
+  },
+  "identity" : {
+    "legend": "Select 'yes' if you are the applicants friend, family member, employer, a community group or a supporting organisation",
+    "options": {
+      "no": {
+        "label": "No"
+      },
+      "yes": {
+        "label": "Yes"
       }
     }
   }

--- a/apps/fbis-ccf/translations/src/en/pages.json
+++ b/apps/fbis-ccf/translations/src/en/pages.json
@@ -8,6 +8,12 @@
   "question": {
     "header": "What is your technical problem about?"
   },
+  "identity": {
+    "header": "Are you contacting us on behalf of someone else?"
+  },
+  "details": {
+    "header": "Your details"
+  },
   "query": {
     "header": {
       "status": "Tell us about a problem viewing or proving your immigration status",

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -1,9 +1,12 @@
 {
+  "representative-name": {
+    "required": "Enter your full name"
+  },
   "query": {
     "required": "Enter details of the problem",
     "maxlength": "Summary must be 500 characters or fewer"
   },
-  "name": {
+  "applicant-name": {
     "required": "Enter your full name"
   },
   "email": {
@@ -15,5 +18,8 @@
   },
   "question": {
     "required": "Select what your technical problem is about"
+  },
+  "identity": {
+    "required": "Select if you are contacting us on behalf of someone else"
   }
 }

--- a/apps/fbis-ccf/views/details.html
+++ b/apps/fbis-ccf/views/details.html
@@ -1,0 +1,11 @@
+{{<step}}
+    {{$page-content}}
+       <label class="form-label">
+           <span id="representative-name-hint" class="form-hint">{{#t}}fields.details.hint{{/t}}</span>
+       </label>
+        {{#fields}}
+            {{#renderField}}{{/renderField}}
+        {{/fields}}
+        {{#input-submit}}save{{/input-submit}}
+    {{/page-content}}
+{{/step}}

--- a/apps/fbis-ccf/views/query.html
+++ b/apps/fbis-ccf/views/query.html
@@ -15,9 +15,9 @@
 
     {{$page-content}}
         {{#textarea}}query{{/textarea}}
-        {{#input-text}}name{{/input-text}}
+        {{#input-text}}applicant-name{{/input-text}}
         {{#input-text}}email{{/input-text}}
-        {{#input-text}}phone{{/input-text}}
+        {{#input-text}}applicant-phone{{/input-text}}
         {{^values.is-id-check}}
             {{#input-text}}application-number{{/input-text}}
         {{/values.is-id-check}}

--- a/apps/fbis-ccf/views/save-and-continue.html
+++ b/apps/fbis-ccf/views/save-and-continue.html
@@ -1,3 +1,4 @@
+<!--Reuseable template for all pages that require 'Save and continue' button-->
 {{<step}}
     {{$page-content}}
     {{#fields}}

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -5,16 +5,30 @@
   width: 100%;
 }
 
+#representative-name-hint {
+  margin-bottom: 1em;
+}
+
+#identity-group {
+  .multiple-choice {
+    clear: right;
+    margin-right: 2em;
+  }
+  legend {
+    margin-bottom: 1em;
+  }
+}
+
 @media (min-width: 641px) {
   #query {
     height: 150px; // 6x default line-height for this screen width
   }
 
-  #name, #email {
+  #applicant-name, #representative-name, #representative-phone, #email {
     width: 80%;
   }
 
-  #phone, #application-number {
+  #applicant-phone, #organisation, #application-number {
     width: 67%;
   }
 }


### PR DESCRIPTION
## What 
Adds new pages to get users identity and collect representative's details.
## Why
So the SRC can respond to the representative rather than applicant to resolve the query if required.
## How
Uses HOF fork approach in fbiscc/index.js to send user down correct route and additional labelling for text content on the query page.
## Test
No new behaviours added. Tested manually for now, awaiting automation testing approach.
## Screenshots
<img width="648" alt="Screenshot 2020-10-28 at 11 31 29" src="https://user-images.githubusercontent.com/61828376/97430828-579d5800-1911-11eb-9ba2-fafabedd262f.png">
<img width="726" alt="Screenshot 2020-10-28 at 11 31 35" src="https://user-images.githubusercontent.com/61828376/97430834-59671b80-1911-11eb-86b6-16bffa2ed63a.png">
<img width="666" alt="Screenshot 2020-10-28 at 11 31 53" src="https://user-images.githubusercontent.com/61828376/97430838-5a984880-1911-11eb-82cf-fbca0e882535.png">
