### PR TITLE
FBISCC-33: corrects text content for labels and legends

### DIFF
--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -3,7 +3,7 @@
     "hint": "Details of the person filling out this form"
   },
   "representative-name": {
-    "label": "Full name"
+    "label": "Your full name"
   },
   "representative-phone": {
     "label": "Your phone number (optional)"
@@ -34,8 +34,8 @@
   "applicant-phone": {
     "label": {
       "identity": {
-        "no" : "Phone number",
-        "yes": "Applicant's phone number"
+        "no" : "Phone number (optional)",
+        "yes": "Applicant's phone number (optional)"
       }
     }
   },
@@ -63,7 +63,7 @@
     }
   },
   "identity" : {
-    "legend": "Select 'yes' if you are the applicants friend, family member, employer, a community group or a supporting organisation",
+    "legend": "Select 'yes' if you are the applicant's friend, family member, employer, a community group or a supporting organisation",
     "options": {
       "no": {
         "label": "No"


### PR DESCRIPTION
## What
Updates labels to indicate phone number being optional. Corrects grammatical error in identity legend.
## Why
So content matches designs
## How
Simple string updates