### PR TITLE
FBISCC-10: confirm and edit responses

### DIFF
--- a/apps/fbis-ccf/behaviours/format-summary-locals.js
+++ b/apps/fbis-ccf/behaviours/format-summary-locals.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = SuperClass => class FormatSummaryLocals extends SuperClass {
+
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    locals.rows[0] = this.formatQuestionSection(req, locals.rows[0]);
+    locals.rows[locals.rows.length - 1] = this.formatQuerySection(req, locals.rows[locals.rows.length - 1]);
+    return locals;
+  }
+
+  formatQuestionSection(req, questionSection) {
+    questionSection.fields[0].value = req.translate(`fields.question.options.${req.form.values.question}.label`);
+    return questionSection;
+  }
+
+  formatQuerySection(req, querySection) {
+    querySection.section = req.translate(`pages.query.header.${req.form.values.question}`);
+
+    querySection.fields.map(field => {
+      if (field.field !== 'query') {
+        field.label = req.translate(`fields.${field.field}.label.identity.${req.form.values.identity}`);
+      }
+      return field;
+    });
+
+    return querySection;
+  }
+
+};

--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -4,7 +4,7 @@ module.exports = {
   identity: {
     mixin: 'radio-group',
     validate: ['required'],
-    options: ['no', 'yes']
+    options: ['No', 'Yes']
   },
   'representative-name': {
     validate: ['required']

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -5,6 +5,7 @@ const addUANValidatorIfRequired = require('./behaviours/add-uan-validator-if-req
 const setLocationOnSession = require('./behaviours/set-location-on-session');
 const setQuestionFlagsOnValues = require('./behaviours/set-question-flags-on-values');
 const summaryPage = require('hof-behaviour-summary-page');
+const formatSummaryLocals = require('./behaviours/format-summary-locals');
 
 module.exports = {
   name: 'fbis-ccf',
@@ -28,7 +29,7 @@ module.exports = {
         target: '/details',
         condition: {
           field: 'identity',
-          value: 'yes'
+          value: 'Yes'
         }
       }],
     },
@@ -42,7 +43,7 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: ['complete', summaryPage],
+      behaviours: ['complete', summaryPage, formatSummaryLocals],
       next: '/complete'
     },
     '/complete': {

--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -18,32 +18,32 @@
   "applicant-name": {
     "label": {
       "identity": {
-        "no" : "Full name",
-        "yes": "Applicant's full name"
+        "No" : "Full name",
+        "Yes": "Applicant's full name"
       }
     }
   },
   "email": {
     "label": {
       "identity": {
-        "no" : "Email address",
-        "yes": "Applicant's email address"
+        "No" : "Email address",
+        "Yes": "Applicant's email address"
       }
     }
   },
   "applicant-phone": {
     "label": {
       "identity": {
-        "no" : "Phone number (optional)",
-        "yes": "Applicant's phone number (optional)"
+        "No" : "Phone number (optional)",
+        "Yes": "Applicant's phone number (optional)"
       }
     }
   },
   "application-number": {
     "label": {
       "identity": {
-        "no" : "Unique application number (UAN)",
-        "yes": "Applicant's unique application number (UAN)"
+        "No" : "Unique application number (UAN)",
+        "Yes": "Applicant's unique application number (UAN)"
       }
     },
     "hint": "For example, 3434-0000-0000-0001"
@@ -63,12 +63,12 @@
     }
   },
   "identity" : {
-    "legend": "Select 'yes' if you are the applicant's friend, family member, employer, a community group or a supporting organisation",
+    "legend": "Select 'Yes' if you are the applicant's friend, family member, employer, a community group or a supporting organisation",
     "options": {
-      "no": {
+      "No": {
         "label": "No"
       },
-      "yes": {
+      "Yes": {
         "label": "Yes"
       }
     }

--- a/apps/fbis-ccf/translations/src/en/pages.json
+++ b/apps/fbis-ccf/translations/src/en/pages.json
@@ -20,5 +20,8 @@
       "account": "Tell us about a problem updating your immigration account details",
       "id-check": "Tell us about a problem with the 'ID check' app"
     }
+  },
+  "confirm": {
+    "header": "Check your answers"
   }
 }

--- a/apps/fbis-ccf/views/partials/maincontent-left.html
+++ b/apps/fbis-ccf/views/partials/maincontent-left.html
@@ -1,0 +1,10 @@
+{{$content-outer}}
+{{$preloader}}{{/preloader}}
+<div id="{{route}}-column" class="column-two-thirds">
+    {{$validationSummary}}{{/validationSummary}}
+    <header>
+        <h1>{{$header}}{{/header}}</h1>
+    </header>
+    {{$content}}{{/content}}
+</div>
+{{/content-outer}}

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,5 +1,9 @@
 // Custom styling for overriding HOF defaults as required by designs
 
+#confirm-column.column-two-thirds {
+  width: 100%;
+}
+
 #query {
   height: 120px; // 6x default line-height for screens < 641px wide
   width: 100%;

--- a/test/format-summary-locals.spec.js
+++ b/test/format-summary-locals.spec.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const Behaviour = require('../apps/fbis-ccf/behaviours/format-summary-locals');
+const fields = require('../apps/fbis-ccf/translations/src/en/fields');
+const pages = require('../apps/fbis-ccf/translations/src/en/pages');
+const translations = { fields, pages};
+
+describe('Format summary locals behaviour', () => {
+
+  let req;
+  let res;
+  let rows;
+  let FormatSummaryLocals;
+  let testInstance;
+
+  beforeEach(() => {
+    req = {
+      translate: (JSONPath) => {
+        return JSONPath.split('.').reduce((object, key) => {
+          return object && object[key];
+        }, translations);
+      },
+      form: {
+        values: {}
+      }
+    };
+
+    res = {};
+
+  });
+
+  describe('locals', () => {
+
+    class Base {
+      locals() {
+        return { rows };
+      }
+    }
+
+    beforeEach(() => {
+      FormatSummaryLocals = Behaviour(Base);
+      testInstance = new FormatSummaryLocals();
+    });
+
+
+    it('should add descriptive text for id-check if question is id-check', () => {
+      rows = [
+        { fields: [{}], section: null },
+        { fields: [{}], section: null }
+      ];
+
+      req.form.values.question = 'id-check';
+
+      const expected = {
+        rows: [{
+          fields: [{ value: 'The \'ID check\' app' }],
+          section: null
+        }, {
+          fields: [{ label: undefined }],
+          section: 'Tell us about a problem with the \'ID check\' app'
+        }],
+      };
+
+      expect(testInstance.locals(req, res)).to.deep.equal(expected);
+    });
+
+    it('should add descriptive text for status if question is status', () => {
+      rows = [
+        { fields: [{}], section: null },
+        { fields: [{}], section: null }
+      ];
+
+      req.form.values.question = 'status';
+
+      const expected = {
+        rows: [{
+          fields: [{ value: 'Viewing or proving your immigration status' }],
+          section: null
+        }, {
+          fields: [{ label: undefined }],
+          section: 'Tell us about a problem viewing or proving your immigration status'
+        }],
+      };
+
+      expect(testInstance.locals(req, res)).to.deep.equal(expected);
+    });
+
+    it('should add descriptive text for status if question is account', () => {
+      rows = [
+        { fields: [{}], section: null },
+        { fields: [{}], section: null }
+      ];
+
+      req.form.values.question = 'account';
+
+      const expected = {
+        rows: [{
+          fields: [{ value: 'Updating your immigration account details' }],
+          section: null
+        }, {
+          fields: [{ label: undefined }],
+          section: 'Tell us about a problem updating your immigration account details'
+        }],
+      };
+
+      expect(testInstance.locals(req, res)).to.deep.equal(expected);
+    });
+
+    it('should add applicant prefix to field labels if user is a representative', () => {
+      rows = [
+        {
+          fields: [{}],
+          section: null
+        }, {
+          fields: [{
+            field: 'applicant-name'
+          }, {
+            field: 'applicant-phone'
+          }, {
+            field: 'email'
+          }, {
+            field: 'application-number'
+          }],
+          section: null
+        }
+      ];
+
+      req.form.values.identity = 'Yes';
+
+      const expected = {
+        rows: [
+          {
+            fields: [{ value: undefined }],
+            section: null
+          }, {
+            fields: [{
+              field: 'applicant-name',
+              label: 'Applicant\'s full name'
+            }, {
+              field: 'applicant-phone',
+              label: 'Applicant\'s phone number (optional)'
+            }, {
+              field: 'email',
+              label: 'Applicant\'s email address'
+            }, {
+              field: 'application-number',
+              label: 'Applicant\'s unique application number (UAN)'
+            }],
+            section: undefined
+          }
+        ]
+      };
+
+      expect(testInstance.locals(req, rows)).to.deep.equal(expected);
+    });
+
+    it('should not add applicant prefix to field labels if user is the applicant', () => {
+      rows = [
+        {
+          fields: [{}],
+          section: null
+        }, {
+          fields: [{
+            field: 'applicant-name'
+          }, {
+            field: 'applicant-phone'
+          }, {
+            field: 'email'
+          }, {
+            field: 'application-number'
+          }],
+          section: null
+        }
+      ];
+
+      req.form.values.identity = 'No';
+
+      const expected = {
+        rows: [
+          {
+            fields: [{ value: undefined }],
+            section: null
+          }, {
+            fields: [{
+              field: 'applicant-name',
+              label: 'Full name'
+            }, {
+              field: 'applicant-phone',
+              label: 'Phone number (optional)'
+            }, {
+              field: 'email',
+              label: 'Email address'
+            }, {
+              field: 'application-number',
+              label: 'Unique application number (UAN)'
+            }],
+            section: undefined
+          }
+        ]
+      };
+
+      expect(testInstance.locals(req, rows)).to.deep.equal(expected);
+    });
+
+  });
+
+});


### PR DESCRIPTION
## What
First pass at the confirmation and editing page, using correct labels and section headings depending on the user's question topic and identity.
## Why
So that user's understand how the answers they are checking relate to the fields they entered them for.
## How
Adds 'format-summary-locals' behaviour to supplement the default 'hof-behaviour-summary-page' behaviour with business logic specific to FBIS. 
## Test
Unit tests added for the new behaviour.
## Screenshots
![Screenshot 2020-10-30 at 14 17 20](https://user-images.githubusercontent.com/43788672/97716089-19439c80-1abb-11eb-9b75-10c44d7474a1.png)
