### PR TITLE
FBISCC-31: UAN validation

### DIFF
--- a/apps/fbis-ccf/behaviours/add-uan-validator-if-required.js
+++ b/apps/fbis-ccf/behaviours/add-uan-validator-if-required.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const customValidators = require('../validators/index');
+
 module.exports = superclass => class AddUANValidatorIfRequired extends superclass {
 
   process(req, res, next) {
     const isUANRequired = req.sessionModel.get('question') !== 'id-check';
 
     if (isUANRequired) {
-      req.form.options.fields['application-number'].validate = ['required'];
+      req.form.options.fields['application-number'].validate = ['required', customValidators.uan];
     }
 
     return super.process(req, res, next);

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -14,7 +14,8 @@
     "email": "Enter a valid email address"
   },
   "application-number": {
-    "required": "Enter your unique application number (UAN)"
+    "required": "Enter your unique application number (UAN)",
+    "uan": "Enter a valid unique application number (UAN)"
   },
   "question": {
     "required": "Select what your technical problem is about"

--- a/apps/fbis-ccf/validators/index.js
+++ b/apps/fbis-ccf/validators/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function uan(value) {
+  return typeof value === 'string' && !!value.match(/^(1212|3434)(-\d{4}){3}$/);
+}
+
+module.exports = {
+  uan
+};

--- a/test/add-uan-validator-if-required.spec.js
+++ b/test/add-uan-validator-if-required.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Behaviour = require('../apps/fbis-ccf/behaviours/add-uan-validator-if-required');
+const uanValidator = require('../apps/fbis-ccf/validators/index').uan;
 
 describe('Add UAN validator if required behaviour', () => {
 
@@ -40,13 +41,13 @@ describe('Add UAN validator if required behaviour', () => {
     it('should add `required` validator to application number if question is status', () => {
       req.sessionModel.get.returns('status');
       testInstance.process(req, res, () => {});
-      expect(req.form.options.fields['application-number'].validate).to.deep.equal(['required']);
+      expect(req.form.options.fields['application-number'].validate).to.deep.equal(['required', uanValidator]);
     });
 
     it('should add `required` validator to application number if question is account', () => {
       req.sessionModel.get.returns('account');
       testInstance.process(req, res, () => {});
-      expect(req.form.options.fields['application-number'].validate).to.deep.equal(['required']);
+      expect(req.form.options.fields['application-number'].validate).to.deep.equal(['required', uanValidator]);
     });
 
     it('should not add `required` validator to application number if question is id-check', () => {

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const validators = require('../apps/fbis-ccf/validators/index');
+
+describe('Custom validators', () => {
+
+  describe('uan', () => {
+
+    it('should approve a string of 16 digits, hyphen-split into 4 groups of 4, beginning with 1212', () => {
+      expect(validators.uan('1212-1230-5896-8432')).to.equal(true);
+    });
+
+    it('should approve a string of 16 digits, hyphen-split into 4 groups of 4, beginning with 1212', () => {
+      expect(validators.uan('3434-1230-5896-8432')).to.equal(true);
+    });
+
+    it('should reject strings of 16 digits, hyphen-split into 4 groups of 4, beginning not with 1212 or 3434', () => {
+      expect(validators.uan('1111-1230-5896-8432')).to.equal(false);
+    });
+
+    it('should reject strings of 16 digits, not hyphen split into 4 groups of 4', () => {
+      expect(validators.uan('1212123058968432')).to.equal(false);
+      expect(validators.uan('1212-123058968432')).to.equal(false);
+      expect(validators.uan('1212-1230-58968-432')).to.equal(false);
+    });
+
+    it('should reject strings with characters that are not digits', () => {
+      expect(validators.uan('1212-123O-5896-8432')).to.equal(false);
+    });
+
+    it('should reject non-strings', () => {
+      expect(validators.uan(1212123058968432)).to.equal(false);
+    });
+
+  });
+
+});


### PR DESCRIPTION
## What
Adds validation of UAN field
## Why
So that users can not submit a query if the UAN field is invalid, which would mean the SRC could not connect their query to an existing application.
## How
Adds a custom validator to apps/fbiscc/validators/index.js
## Test
New unit tests added
## Screenshots
If the field is empty:
![Screenshot 2020-10-30 at 15 18 58](https://user-images.githubusercontent.com/43788672/97723082-4a27cf80-1ac3-11eb-86b7-ff12b47b4943.png)
If the input is invalid:
![Screenshot 2020-10-30 at 15 19 07](https://user-images.githubusercontent.com/43788672/97723078-498f3900-1ac3-11eb-9a57-966ae737963a.png)
