### PR TITLE
FBISCC-37: add logging to notify integration

### DIFF
--- a/apps/fbis-ccf/behaviours/submit.js
+++ b/apps/fbis-ccf/behaviours/submit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const config = require('../../../config');
+const notify = require('../../../config').notify;
 const sendEmail = require('../../../lib/utils').sendEmail;
 const fields = require('../fields/index');
 const uuidv4 = require('uuid').v4;
@@ -13,9 +13,17 @@ module.exports = superclass => class Submit extends superclass {
       return data;
     }, {});
 
-    return sendEmail(config.notify.templateQuery, config.notify.srcCaseworkEmail, uuidv4(), emailData)
-      .then(() => super.saveValues(req, res, next))
-      .catch(error => next(error));
+    const reference = uuidv4();
+
+    return sendEmail(notify.templateQuery, notify.srcCaseworkEmail, reference, emailData)
+      .then(() => {
+        req.log('info', 'Email sent to SRC casework address', `reference=${reference}`);
+        return super.saveValues(req, res, next);
+      })
+      .catch(error => {
+        req.log('error', 'Error sending email to SRC casework address', `reference=${reference}`, error);
+        return next(error);
+      });
   }
 
 };


### PR DESCRIPTION
## What

Adds logging for email success/failure when user submits the form.

## Why

So that the dev team are informed of whether the key email component of the application is working correctly and action if there are any issues.

## How

Uses HOF's built in logger. Logs a success message and the email reference on success. Logs an error message, the email reference, and the error itself on failure.

## Test

Two new unit tests added to cover the logging. Some existing tests have been refactored to use more use-case like test data.