### PR TITLE
FBISCC-46: redirect base url to landing page

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,7 @@ settings.routes = settings.routes.map(route => require(route));
 settings.root = __dirname;
 settings.start = false;
 
-module.exports = hof(settings);
+const app = hof(settings);
+app.use('', (req, res, next) => req.oriinalUrl === '/' ? res.redirect('/landing') : next());
+
+module.exports = app;


### PR DESCRIPTION
## What

Redirect from the base url to the landing page.

## Why

So that users do not see an error if the navigate to the base url for the service and can start their journey successfully.

## How

Add middleware to the hof express app that redirects to the landing page if original url is base url.