### PR TITLE
FBISCC-46: redirect base url to landing page

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,6 @@ settings.root = __dirname;
 settings.start = false;
 
 const app = hof(settings);
-app.use('', (req, res, next) => req.oriinalUrl === '/' ? res.redirect('/landing') : next());
+app.use('', (req, res, next) => req.originalUrl === '/' ? res.redirect('/landing') : next());
 
 module.exports = app;


### PR DESCRIPTION
## What

Redirect base url to the landing page.

## Why

So that users can start the journey correctly even when using the base url.

## How

Correct type on redirect middleware.

## Test

To be verified in dev environment.