### PR TITLE
FBISCC-46: redirect base url to landing page

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,6 @@ settings.root = __dirname;
 settings.start = false;
 
 const app = hof(settings);
-app.use('', (req, res, next) => req.originalUrl === '/' ? res.redirect('/landing') : next());
+app.use('', (req, res, next) => req.path === '/' ? res.redirect('/landing') : next());
 
 module.exports = app;


### PR DESCRIPTION
## What

Redirect base url to landing page

## Why

So users can start the journey if they use only the base url

## How

Corrects redirect middleware to check path, rather than original url, to fix issue persisting in dev.

## Test

To be validated in dev environment.