### PR TITLE
FBISCC-46: redirect base url to landing page

### DIFF
--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -10,7 +10,6 @@ const summaryPage = require('hof-behaviour-summary-page');
 
 module.exports = {
   name: 'fbis-ccf',
-  baseUrl: '',
   steps: {
     '/landing': {
       behaviours: [setLocationOnSession],

--- a/index.js
+++ b/index.js
@@ -8,7 +8,4 @@ settings.routes = settings.routes.map(route => require(route));
 settings.root = __dirname;
 settings.start = false;
 
-const app = hof(settings);
-app.use('', (req, res, next) => req.path === '/' ? res.redirect('/landing') : next());
-
-module.exports = app;
+module.exports = hof(settings);


### PR DESCRIPTION
## What

Redirect base url to landing page

## Why

So users can start the journey if they use only the base url

## How

Removes middleware redirect approach which was failing in dev. Removes the base url from the fbis sub app, in keeping with the redirect approach found in the reporting modern slavery service.

## Test

To be validated in dev environment.