### PR TITLE
FBISCC-46 Fix: baseurl not working without a path

### DIFF
--- a/kube/branch/ingress-internal.yaml
+++ b/kube/branch/ingress-internal.yaml
@@ -10,7 +10,6 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/ingress.class: "nginx-internal"
     ingress.kubernetes.io/add-base-url: "true"
-    ingress.kubernetes.io/app-root: /
 spec:
   tls:
     - hosts:

--- a/kube/dev/ingress-internal.yaml
+++ b/kube/dev/ingress-internal.yaml
@@ -10,7 +10,6 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/ingress.class: "nginx-internal"
     ingress.kubernetes.io/add-base-url: "true"
-    ingress.kubernetes.io/app-root: /
 spec:
   tls:
     - hosts:

--- a/kube/prod/ingress-external.yaml
+++ b/kube/prod/ingress-external.yaml
@@ -10,7 +10,6 @@ metadata:
     ingress.kubernetes.io/whitelist-source-range: "62.25.109.196/32,52.48.127.144/28,52.209.62.128/25,52.56.62.128/25"
     kubernetes.io/ingress.class: "nginx-external"
     cert-manager.io/enabled: "true"
-    ingress.kubernetes.io/app-root: /
 spec:
   tls:
     - hosts:

--- a/kube/stg/ingress-internal.yaml
+++ b/kube/stg/ingress-internal.yaml
@@ -10,7 +10,6 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/ingress.class: "nginx-internal"
     ingress.kubernetes.io/add-base-url: "true"
-    ingress.kubernetes.io/app-root: /
 spec:
   tls:
     - hosts:

--- a/kube/uat/ingress-internal.yaml
+++ b/kube/uat/ingress-internal.yaml
@@ -10,7 +10,6 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/ingress.class: "nginx-internal"
     ingress.kubernetes.io/add-base-url: "true"
-    ingress.kubernetes.io/app-root: /
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
## What?
Fix the following issue: In our environments we are unable to get to the baseurl without a path `https://fbis-contact-form.dev.internal.sas-notprod.homeoffice.gov.uk/` but this works `https://fbis-contact-form.dev.internal.sas-notprod.homeoffice.gov.uk/landing`

## How?
* Update ingress and remove the `ingress.kubernetes.io/app-root` annotation
* If the root of your application is / then you won't need this, see https://kubernetes.github.io/ingress-nginx/examples/rewrite/#deployment. Setting this to / will mean  visiting / will redirect to / causing an infinite loop.