### PR TITLE
FBISCC-47: prevent multiple form submission

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,3 +18,7 @@ overrides:
       chai: true
       sinon: true
       expect: true
+  - files:
+      "assets/js/*.js"
+    env:
+      browser: true

--- a/apps/fbis-ccf/behaviours/clear-session.js
+++ b/apps/fbis-ccf/behaviours/clear-session.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = superclass => class ClearSession extends superclass {
+
+  getValues(req, res, next) {
+    req.sessionModel.reset();
+    return super.getValues(req, res, next);
+  }
+
+};

--- a/apps/fbis-ccf/behaviours/submit.js
+++ b/apps/fbis-ccf/behaviours/submit.js
@@ -1,29 +1,53 @@
 'use strict';
 
 const notify = require('../../../config').notify;
-const sendEmail = require('../../../lib/utils').sendEmail;
+const utils = require('../../../lib/utils');
 const fields = require('../fields/index');
 const uuidv4 = require('uuid').v4;
 
 module.exports = superclass => class Submit extends superclass {
 
   saveValues(req, res, next) {
+    let reference = req.sessionModel.get(notify.submitEmailSessionName);
+
+    /*
+      If there is already an email reference on the session (i.e. this is not the first submit attempt because
+      the user has clicked submit multiple times), don't resend the email. Check its status and resolve accordingly.
+    */
+    if (reference) {
+      return utils.pollEmailStatus(reference, 0, notify.statusRetryInterval)
+        .then(() => Submit.handleSuccess(req, next, reference, false))
+        .catch(err => Submit.handleError(req, next, reference, err));
+    }
+
+    /*
+      If there is not an email reference on the session (i.e. this is the first time the user clicked submit)
+      create a reference, add it to the session, and send the email with the same reference.
+     */
+    reference = uuidv4();
+    req.sessionModel.set(notify.submitEmailSessionName, reference);
+    req.session.save();
+
     let emailData = Object.keys(fields).reduce((data, field) => {
       data[field] = req.form.historicalValues[field] || 'n/a';
       return data;
     }, {});
 
-    const reference = uuidv4();
+    return utils.sendEmail(notify.templateQuery, notify.srcCaseworkEmail, reference, emailData)
+      .then(() => Submit.handleSuccess(req, next, reference, true))
+      .catch(err => Submit.handleError(req, next, reference, err));
+  }
 
-    return sendEmail(notify.templateQuery, notify.srcCaseworkEmail, reference, emailData)
-      .then(() => {
-        req.log('info', 'Email sent to SRC casework address', `reference=${reference}`);
-        return super.saveValues(req, res, next);
-      })
-      .catch(error => {
-        req.log('error', 'Error sending email to SRC casework address', `reference=${reference}`, error);
-        return next(error);
-      });
+  static handleSuccess(req, next, reference, shouldLog) {
+    if (shouldLog) {
+      req.log('info', 'Email sent to SRC casework address', `reference=${reference}`);
+    }
+    return next();
+  }
+
+  static handleError(req, next, reference, err) {
+    req.log('error', 'Error sending email to SRC casework address', `reference=${reference}`, err);
+    return next(err);
   }
 
 };

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -2,6 +2,7 @@
 
 const addLocationToBacklink = require('./behaviours/add-location-to-backlink');
 const addUANValidatorIfRequired = require('./behaviours/add-uan-validator-if-required');
+const clearSession = require('./behaviours/clear-session');
 const formatSummaryLocals = require('./behaviours/format-summary-locals');
 const setLocationOnSession = require('./behaviours/set-location-on-session');
 const setQuestionFlagsOnValues = require('./behaviours/set-question-flags-on-values');
@@ -43,10 +44,11 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: [summaryPage, formatSummaryLocals, submit, 'complete'],
+      behaviours: [summaryPage, formatSummaryLocals, submit],
       next: '/complete'
     },
     '/complete': {
+      behaviours: [clearSession],
       template: 'confirmation'
     }
   }

--- a/assets/js/disable-multiple-submit.js
+++ b/assets/js/disable-multiple-submit.js
@@ -1,0 +1,9 @@
+'use strict';
+var $ = require('jquery');
+
+$(document).ready(function disableMultipleSubmit() {
+  $('form').submit(function disable() {
+    $(this).find('input[type="submit"]').prop('disabled', true);
+  });
+});
+

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,3 +1,4 @@
 'use strict';
 // eslint-disable-next-line implicit-dependencies/no-implicit
 require('$$theme');
+require('./disable-multiple-submit');

--- a/config.js
+++ b/config.js
@@ -4,7 +4,10 @@
 module.exports = {
   notify: {
     apiKey: process.env.NOTIFY_KEY,
+    templateQuery: process.env.TEMPLATE_QUERY,
+    submitEmailSessionName: 'submit-email-reference',
     srcCaseworkEmail: process.env.SRC_CASEWORK_EMAIL,
-    templateQuery: process.env.TEMPLATE_QUERY
+    statusRetryLimit: 5,
+    statusRetryInterval: 1000
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,31 @@ const sendEmail = (templateId, emailAddress, reference, data) => {
   });
 };
 
+const getEmail = reference => {
+  return notifyClient.getNotifications(undefined, undefined, reference)
+    .then(res => res.data.notifications[0])
+    .catch(() => undefined);
+};
+
+const sleep = ms => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};
+
+const pollEmailStatus = (reference, tries, ms) => {
+  if (tries >= config.notify.statusRetryLimit) {
+    return new Promise((resolve, reject) => {
+      return reject(new Error('Exceeded email status check retry limit'));
+    });
+  }
+
+  return sleep(ms)
+    .then(() => getEmail(reference))
+    .then(email => email ? true : module.exports.pollEmailStatus(reference, tries + 1));
+};
+
 module.exports = {
+  getEmail,
+  pollEmailStatus,
   sendEmail,
+  sleep
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4916,6 +4916,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jquery": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "hof-behaviour-summary-page": "^2.0.0",
     "hof-build": "^1.3.4",
     "hof-theme-govuk": "^5.0.0",
+    "jquery": "^3.5.1",
     "notifications-node-client": "^5.0.0",
     "uuid": "^8.3.1"
   },

--- a/test/behaviours/submit.spec.js
+++ b/test/behaviours/submit.spec.js
@@ -1,15 +1,20 @@
 'use strict';
 
+/* eslint max-nested-callbacks: 0 */
+
 const proxyquire = require('proxyquire');
 
 const mockUtils = {
-  sendEmail: sinon.stub()
+  sendEmail: sinon.stub(),
+  pollEmailStatus: sinon.stub()
 };
 
 const mockConfig = {
   notify: {
     templateQuery: 'templateQuery',
-    srcCaseworkEmail: 'srcCaseworkEmail'
+    srcCaseworkEmail: 'srcCaseworkEmail',
+    submitEmailSessionName: 'submit-email',
+    statusRetryInterval: 1000
   }
 };
 
@@ -37,7 +42,14 @@ describe('Submit behaviour', () => {
       form: {
         historicalValues: {}
       },
-      log: sinon.stub()
+      log: sinon.stub(),
+      sessionModel: {
+        get: sinon.stub(),
+        set: sinon.stub()
+      },
+      session: {
+        save: sinon.stub()
+      }
     };
 
     res = {};
@@ -58,120 +70,195 @@ describe('Submit behaviour', () => {
     });
 
     afterEach(() => {
-      mockUtils.sendEmail.resetHistory();
-      req.log.resetHistory();
+      mockUtils.sendEmail.reset();
+      req.log.reset();
     });
 
-    it('should call utils \'sendEmail\' with template query, SRC casework email, and a UUID', () => {
-      testInstance.saveValues(req, res, nextStub)
-        .then(() => {
-          expect(mockUtils.sendEmail).to.have.been.calledOnceWith('templateQuery', 'srcCaseworkEmail', 'mockUUID');
-        });
+    describe('on first submit', () => {
+
+      beforeEach(() => {
+        req.sessionModel.get.withArgs(mockConfig.notify.submitEmailSessionName).returns(undefined);
+      });
+
+      afterEach(() => {
+        req.sessionModel.get.reset();
+      });
+
+      it('should call utils \'sendEmail\' with template query, SRC casework email, and a UUID', () => {
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(mockUtils.sendEmail).to.have.been.calledOnceWith('templateQuery', 'srcCaseworkEmail', 'mockUUID');
+          });
+      });
+
+      it('should call utils \'sendEmail\' with emailData containing only necessary fields from the form', () => {
+        req.form.historicalValues = {
+          'some-unwanted-field': 'unwanted value',
+          'applicant-name': 'John Smith',
+          'applicant-phone': '07000000000',
+          'application-number': '3434-0000-0000-0001',
+          email: 'john.smith@mail.com',
+          identity: 'yes',
+          organisation: 'Charity',
+          query: 'I am having an issue',
+          question: 'account',
+          'representative-name': 'Mary Sue',
+          'representative-phone': '07111111111'
+        };
+
+        const expected = {
+          'applicant-name': 'John Smith',
+          'applicant-phone': '07000000000',
+          'application-number': '3434-0000-0000-0001',
+          email: 'john.smith@mail.com',
+          identity: 'yes',
+          organisation: 'Charity',
+          query: 'I am having an issue',
+          question: 'account',
+          'representative-name': 'Mary Sue',
+          'representative-phone': '07111111111'
+        };
+
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(mockUtils.sendEmail).to.have.been
+              .calledOnceWith('templateQuery', 'srcCaseworkEmail', 'mockUUID', expected);
+          });
+      });
+
+      it('should call substitute falsy form fields with \'n/a\'', () => {
+        req.form.historicalValues = {
+          'applicant-name': 'John Smith',
+          'applicant-phone': '',
+          'application-number': null,
+          email: 'john.smith@mail.com',
+          identity: 'no',
+          organisation: undefined,
+          query: 'I am having an issue',
+          question: 'account',
+          'representative-name': false,
+          'representative-phone': false
+        };
+
+        const expected = {
+          'applicant-name': 'John Smith',
+          'applicant-phone': 'n/a',
+          'application-number': 'n/a',
+          email: 'john.smith@mail.com',
+          identity: 'no',
+          organisation: 'n/a',
+          query: 'I am having an issue',
+          question: 'account',
+          'representative-name': 'n/a',
+          'representative-phone': 'n/a'
+        };
+
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(mockUtils.sendEmail).to.have.been
+              .calledOnceWith('templateQuery', 'srcCaseworkEmail', 'mockUUID', expected);
+          });
+      });
+
+      it('should call the next middleware step if the email sends successfully', () => {
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(nextStub.calledOnce).to.equal(true);
+          });
+      });
+
+      it('should log a success message and the email reference if the email sends successfully', () => {
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(req.log).to.have.been.calledOnceWith(
+              'info',
+              'Email sent to SRC casework address',
+              'reference=mockUUID'
+            );
+          });
+      });
+
+      it('should pass the error to the next middleware step if there is an error sending the email', () => {
+        const testError = new Error('testError');
+        mockUtils.sendEmail.rejects(testError);
+
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(nextStub).to.have.been.calledOnceWith(testError);
+          });
+      });
+
+      it('should log the error and email reference if there is an error sending the email', () => {
+        const testError = new Error('testError');
+        mockUtils.sendEmail.rejects(testError);
+
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(req.log).to.have.been.calledOnceWith(
+              'error',
+              'Error sending email to SRC casework address',
+              'reference=mockUUID',
+              testError
+            );
+          });
+      });
+
     });
 
-    it('should call utils \'sendEmail\' with emailData containing only necessary fields from the form', () => {
-      req.form.historicalValues = {
-        'some-unwanted-field': 'unwanted value',
-        'applicant-name': 'John Smith',
-        'applicant-phone': '07000000000',
-        'application-number': '3434-0000-0000-0001',
-        email: 'john.smith@mail.com',
-        identity: 'yes',
-        organisation: 'Charity',
-        query: 'I am having an issue',
-        question: 'account',
-        'representative-name': 'Mary Sue',
-        'representative-phone': '07111111111'
-      };
+    describe('on duplicate submit', () => {
 
-      const expected = {
-        'applicant-name': 'John Smith',
-        'applicant-phone': '07000000000',
-        'application-number': '3434-0000-0000-0001',
-        email: 'john.smith@mail.com',
-        identity: 'yes',
-        organisation: 'Charity',
-        query: 'I am having an issue',
-        question: 'account',
-        'representative-name': 'Mary Sue',
-        'representative-phone': '07111111111'
-      };
+      beforeEach(() => {
+        req.sessionModel.get.withArgs(mockConfig.notify.submitEmailSessionName).returns('mockUUID');
+      });
 
-      testInstance.saveValues(req, res, nextStub)
-        .then(() => {
-          expect(mockUtils.sendEmail).to.have.been
-            .calledOnceWith('templateQuery', 'srcCaseworkEmail', 'mockUUID', expected);
-        });
-    });
+      afterEach(() => {
+        req.sessionModel.get.reset();
+        mockUtils.pollEmailStatus.reset();
+      });
 
-    it('should call substitute falsy form fields with \'n/a\'', () => {
-      req.form.historicalValues = {
-        'applicant-name': 'John Smith',
-        'applicant-phone': '',
-        'application-number': null,
-        email: 'john.smith@mail.com',
-        identity: 'no',
-        organisation: undefined,
-        query: 'I am having an issue',
-        question: 'account',
-        'representative-name': false,
-        'representative-phone': false
-      };
+      it('should call the next middleware step if polling is successful', () => {
+        mockUtils.pollEmailStatus.resolves();
 
-      const expected = {
-        'applicant-name': 'John Smith',
-        'applicant-phone': 'n/a',
-        'application-number': 'n/a',
-        email: 'john.smith@mail.com',
-        identity: 'no',
-        organisation: 'n/a',
-        query: 'I am having an issue',
-        question: 'account',
-        'representative-name': 'n/a',
-        'representative-phone': 'n/a'
-      };
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(nextStub.calledOnce).to.equal(true);
+          });
+      });
 
-      testInstance.saveValues(req, res, nextStub)
-        .then(() => {
-          expect(mockUtils.sendEmail).to.have.been
-            .calledOnceWith('templateQuery', 'srcCaseworkEmail', 'mockUUID', expected);
-        });
-    });
+      it('should not log the success as this would duplicate the original submit log', () => {
+        mockUtils.pollEmailStatus.resolves();
 
-    it('should log a success message and the email reference if the email sends successfully', () => {
-      testInstance.saveValues(req, res, nextStub)
-        .then(() => {
-          expect(req.log).to.have.been.calledOnceWith(
-            'info',
-            'Email sent to SRC casework address',
-            'reference=mockUUID'
-          );
-        });
-    });
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(req.log.notCalled).to.equal(true);
+          });
+      });
 
-    it('should pass the error to the next middleware step if there is an error sending the email', () => {
-      const testError = new Error('testError');
-      mockUtils.sendEmail.rejects(testError);
+      it('should pass the error to the next middleware step if there is an error when polling', () => {
+        const testError = new Error('testError');
+        mockUtils.pollEmailStatus.rejects(testError);
 
-      testInstance.saveValues(req, res, nextStub)
-        .then(() => {
-          expect(nextStub).to.have.been.calledOnceWith(testError);
-        });
-    });
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(nextStub).to.have.been.calledOnceWith(testError);
+          });
+      });
 
-    it('should log the error and email reference if there is an error sending the email', () => {
-      const testError = new Error('testError');
-      mockUtils.sendEmail.rejects(testError);
+      it('should log the error and email reference if there is an error sending the email', () => {
+        const testError = new Error('testError');
+        mockUtils.pollEmailStatus.rejects(testError);
 
-      testInstance.saveValues(req, res, nextStub)
-        .then(() => {
-          expect(req.log).to.have.been.calledOnceWith(
-            'error',
-            'Error sending email to SRC casework address',
-            'reference=mockUUID',
-            testError
-          );
-        });
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(req.log).to.have.been.calledOnceWith(
+              'error',
+              'Error sending email to SRC casework address',
+              'reference=mockUUID',
+              testError
+            );
+          });
+      });
+
     });
 
   });

--- a/test/lib/utils.spec.js
+++ b/test/lib/utils.spec.js
@@ -1,9 +1,12 @@
 'use strict';
 
+/* eslint max-nested-callbacks: 0 */
+
 const proxyquire = require('proxyquire');
 
 const mockNotifyClient = {
-  sendEmail: sinon.stub()
+  sendEmail: sinon.stub(),
+  getNotifications: sinon.stub()
 };
 
 const mockNotifyModule = {
@@ -11,6 +14,12 @@ const mockNotifyModule = {
 };
 
 const utils = proxyquire('../../lib/utils', { 'notifications-node-client': mockNotifyModule });
+const config = require('../../config');
+
+afterEach(() => {
+  mockNotifyClient.sendEmail.reset();
+  mockNotifyClient.getNotifications.reset();
+});
 
 describe('Utils', () => {
 
@@ -24,6 +33,84 @@ describe('Utils', () => {
       utils.sendEmail('testTemplate', 'testAddress', 'testReference', 'testData');
 
       expect(mockNotifyClient.sendEmail).to.have.been.calledOnceWith('testTemplate', 'testAddress', expectedOptions);
+    });
+
+  });
+
+
+  describe('getEmail', () => {
+
+    it('should return the email if it exists', () => {
+      mockNotifyClient.getNotifications.resolves({ data: { notifications: ['testEmailData'] } });
+
+      return utils.getEmail('testRef')
+        .then(res => {
+          expect(res).to.equal('testEmailData');
+        });
+    });
+
+    it('should return undefined if the email does not exist', () => {
+      mockNotifyClient.getNotifications.resolves({ data: { notifications: [] } });
+
+      return utils.getEmail('testRef')
+        .then(res => {
+          expect(res).to.equal(undefined);
+        });
+    });
+
+    it('should return undefined if there is an error', () => {
+      mockNotifyClient.getNotifications.rejects(new Error('testError'));
+
+      return utils.getEmail('testRef')
+        .then(res => {
+          expect(res).to.equal(undefined);
+        });
+    });
+
+  });
+
+  describe('pollEmailStatus', () => {
+
+    let pollEmailStatusSpy;
+
+    beforeEach(() => {
+      pollEmailStatusSpy = sinon.spy(utils, 'pollEmailStatus');
+    });
+
+    afterEach(() => {
+      pollEmailStatusSpy.restore();
+    });
+
+    it('should return true if email is found', () => {
+      mockNotifyClient.getNotifications.resolves({ data: { notifications: ['testEmailData'] } });
+
+      const promise = utils.pollEmailStatus('testRef', 0, 0);
+      return promise.then((res) => {
+        expect(res).to.equal(true);
+      });
+    });
+
+    it('should recurse until email is found', () => {
+      mockNotifyClient.getNotifications.onCall(0).resolves({ data: { notifications: [] } });
+      mockNotifyClient.getNotifications.onCall(1).resolves({ data: { notifications: [] } });
+      mockNotifyClient.getNotifications.onCall(2).resolves({ data: { notifications: ['testEmailData'] } });
+
+      const promise = utils.pollEmailStatus('testRef', 0, 0);
+      return promise.then((res) => {
+        expect(pollEmailStatusSpy.getCalls().length).to.equal(3);
+        expect(res).to.equal(true);
+      });
+    });
+
+    it('should throw an error with explanatory message if tries exceeds the retry limit', () => {
+      mockNotifyClient.getNotifications.resolves({ data: { notifications: [] } });
+
+      return utils.pollEmailStatus('testRef', 0, 0)
+        .catch(err => {
+          expect(pollEmailStatusSpy.lastCall.args[1]).to.equal(config.notify.statusRetryLimit);
+          expect(pollEmailStatusSpy.getCalls().length).to.equal(config.notify.statusRetryLimit + 1);
+          expect(err.message).to.equal('Exceeded email status check retry limit');
+        });
     });
 
   });


### PR DESCRIPTION
## What

Prevent multiple submissions of the same query

## Why

So that the SRC does not receive duplicate emails for the same query

## How

Client-side:
* `disable-multiple-submit` script in assets disables buttons on submit

Server-side (if client has JS disabled or removes client-side protection):
* `submit` behaviour stores the email reference on first submit, before send
* each submit checks if the reference exists on the session
* if reference exists, poll notify to check if the email has reached them and resolve accordingly
* poll is set to retry up to 5 times before failing
* poll failures are handled in the same was as an email failing on a single submit
* poll timeout is set to 1 second
* poll retry and timeout both set in config

## Test:
Tests added for new `utils` functions (polling and getting email status from notify) and the updated `submit` behaviour.