### PR TITLE
FBISCC-47: throttle multiple submits on client side

### DIFF
--- a/assets/js/disable-multiple-submit.js
+++ b/assets/js/disable-multiple-submit.js
@@ -1,9 +1,24 @@
 'use strict';
 var $ = require('jquery');
+var throttleTImeout = require('../../config').submitThrottleTimeout;
+
 
 $(document).ready(function disableMultipleSubmit() {
-  $('form').submit(function disable() {
-    $(this).find('input[type="submit"]').prop('disabled', true);
+
+  $('form').submit(function disable(e) {
+    var $inputSubmit = $(this).find('input[type="submit"]');
+
+    if ($inputSubmit.data('throttle') === true) {
+      e.preventDefault();
+      return;
+    }
+
+    $inputSubmit.data('throttle', true);
+
+    setTimeout(() => {
+      $inputSubmit.data('throttle', false);
+    }, throttleTImeout);
   });
+
 });
 

--- a/config.js
+++ b/config.js
@@ -2,6 +2,7 @@
 /* eslint no-process-env: 0 */
 
 module.exports = {
+  submitThrottleTimeout: 1000,
   notify: {
     apiKey: process.env.NOTIFY_KEY,
     templateQuery: process.env.TEMPLATE_QUERY,


### PR DESCRIPTION
## What

Refactor client-side prevention of multiple submits to throttle, rather than completely disable the submit button.

## Why

So that users are not prevented from submitting the form if the button is disabled on a false submit.

## How

Revised client-side script to disable multiple submission. Now sets a 'throttle' data attribute on a timeout to prevent more than one submission per second. Has the added benefit of not using the disabled CSS class, so there is no jarring temporary style change when the page is submitted.