### PR TITLE
FBISCC-44 Change maximum character count of customer query to 2000

### DIFF
--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -13,7 +13,7 @@ module.exports = {
   organisation: {},
   query: {
     mixin: 'textarea',
-    validate: ['required', { type: 'maxlength', arguments: 500 }],
+    validate: ['required', { type: 'maxlength', arguments: 2000 }],
   },
   'applicant-name': {
     validate: ['required'],


### PR DESCRIPTION
**What**
Updates maximum characters of customer query to 2000
**Why**
To be in line with designs
**How**
Simple argument change from 500 -> 2000 in fields/index validator for query