### PR TITLE
FBISCC-54: backfilling tests for identity and details pages

### DIFF
--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -4,7 +4,7 @@ module.exports = {
   identity: {
     mixin: 'radio-group',
     validate: ['required'],
-    options: ['No', 'Yes']
+    options: ['Yes', 'No']
   },
   'representative-name': {
     validate: ['required']

--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -42,8 +42,8 @@
   "application-number": {
     "label": {
       "identity": {
-        "No" : "Unique application number (UAN)",
-        "Yes": "Applicant's unique application number (UAN)"
+        "Yes": "Applicant's unique application number (UAN)",
+        "No" : "Unique application number (UAN)"
       }
     },
     "hint": "For example, 3434-0000-0000-0001"

--- a/test/ui/details/details.spec.js
+++ b/test/ui/details/details.spec.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/* eslint max-nested-callbacks: off */
+
+describe('/details', () => {
+
+  beforeEach(async() => {
+    await page.goto(baseURL + '/landing');
+    await submitPage();
+
+    // select any question category and continue
+    const radio = await page.$('input[type="radio"]');
+    await radio.check();
+    await submitPage();
+
+    // select 'Yes', contacting us on behalf of somebody else
+    const yes = await page.$('input#identity-Yes');
+    await yes.click();
+    await submitPage();
+  });
+
+  describe('FR-REP-4 (FBISCC-33) - Collecting representative\'s details', () => {
+
+    it('should include a header with text \'Your details\'', async() => {
+      const header = await page.$('h1');
+      expect(await header.textContent()).to.equal('Your details');
+    });
+
+    it('should include three text input fields with the correct labels', async() => {
+      const textInputs = await page.$$('input[type="text"]');
+      const labels = await page.$$('.form-group label');
+
+      expect(textInputs.length).to.equal(3);
+      expect(labels.length).to.equal(3);
+
+      expect(await labels[0].innerText()).to.equal('Your full name');
+      expect(await labels[1].innerText()).to.equal('Your phone number (optional)');
+      expect(await labels[2].innerText()).to.equal('Your organisation\'s name (optional)');
+    });
+
+    describe('when user submits the page without entering their name', () => {
+
+      it('should stay on the details page, display an error message, and display an error summary', async()=> {
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        const expected = 'Enter your full name';
+
+        expect(await page.url()).to.equal(baseURL + '/details');
+        expect(errorSummaries.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal(expected);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorMessages[0].innerText()).to.equal(expected);
+      });
+
+    });
+
+    describe('when user submits the page after entering their name', () => {
+
+      it('should continue to the query page', async()=> {
+        await page.fill('input#representative-name', 'John Smith');
+        await submitPage();
+        expect(await page.url()).to.equal(baseURL + '/query');
+      });
+
+    });
+
+  });
+
+});

--- a/test/ui/identity/identity.spec.js
+++ b/test/ui/identity/identity.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/* eslint max-nested-callbacks: off */
+
+describe('/identity', () => {
+
+  beforeEach(async() => {
+    await page.goto(baseURL + '/landing');
+    await submitPage();
+
+    // select any question category and continue
+    const radio = await page.$('input[type="radio"]');
+    await radio.check();
+    await submitPage();
+  });
+
+  describe('FR-REP-4 (FBISCC-33) - Collecting representative\'s details', () => {
+
+    it('should include header with text \'Are you contacting us on behalf of someone else?\'', async()=> {
+      const header = await page.$('h1');
+      expect(await header.innerText()).to.equal('Are you contacting us on behalf of someone else?');
+    });
+
+    it('should include two radio buttons with labels \'Yes\' and \'No\'', async()=> {
+      const radios = await page.$$('input[type="radio"]');
+      const labels = await page.$$('.form-group label');
+
+      expect(radios.length).to.equal(2);
+      expect(labels.length).to.equal(2);
+
+      expect(await labels[0].innerText()).to.equal('Yes');
+      expect(await labels[1].innerText()).to.equal('No');
+    });
+
+    describe('when user clicks submit without choosing an option', () => {
+
+      beforeEach(async() => {
+        const radios = await page.$$('input[type="radio"]');
+        for (const radio of radios) {
+          await radio.uncheck();
+        }
+      });
+
+      it('should stay on the identity page, display an error message, and display an error summary', async()=> {
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        const expected = 'Select if you are contacting us on behalf of someone else';
+
+        expect(await page.url()).to.equal(baseURL + '/identity');
+        expect(errorSummaries.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal(expected);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorMessages[0].innerText()).to.equal(expected);
+      });
+
+    });
+
+    describe('when user clicks submit after choosing \'Yes\'', () => {
+
+      beforeEach(async() => {
+        const yes = await page.$('input#identity-Yes');
+        await yes.click();
+        await submitPage();
+      });
+
+      it('should continue to the details page', async() => {
+        expect(await page.url()).to.equal(baseURL + '/details');
+      });
+
+    });
+
+    describe('when user clicks submit after choosing \'No\'', () => {
+
+      beforeEach(async() => {
+        const no = await page.$('input#identity-No');
+        await no.click();
+        await submitPage();
+      });
+
+      it('should continue to the query page', async() => {
+        expect(await page.url()).to.equal(baseURL + '/query');
+      });
+
+    });
+
+  });
+
+});

--- a/test/ui/question/question.spec.js
+++ b/test/ui/question/question.spec.js
@@ -18,7 +18,7 @@ describe('/question', () => {
 
     it('should include three radio buttons with correct query categories', async()=> {
       const radios = await page.$$('input[type="radio"]');
-      const labels = await page.$$('label');
+      const labels = await page.$$('.form-group label');
 
       expect(radios.length).to.equal(3);
       expect(labels.length).to.equal(3);
@@ -33,7 +33,7 @@ describe('/question', () => {
       expect(await submit.getAttribute('value')).to.equal('Continue');
     });
 
-    describe('if user clicks submit without choosing a question', () => {
+    describe('when user clicks submit without choosing a question', () => {
 
       beforeEach(async() => {
         const radios = await page.$$('input[type="radio"]');
@@ -59,7 +59,7 @@ describe('/question', () => {
 
     });
 
-    describe('if user clicks submit after choosing a question', () => {
+    describe('when user clicks submit after choosing a question', () => {
 
       let radios;
 
@@ -94,7 +94,7 @@ describe('/question', () => {
 
     it('should include three radio buttons with correct query categories', async()=> {
       const radios = await page.$$('input[type="radio"]');
-      const labels = await page.$$('label');
+      const labels = await page.$$('.form-group label');
 
       expect(radios.length).to.equal(3);
       expect(labels.length).to.equal(3);
@@ -109,7 +109,7 @@ describe('/question', () => {
       expect(await submit.getAttribute('value')).to.equal('Continue');
     });
 
-    describe('if user clicks submit without choosing a question', () => {
+    describe('when user clicks submit without choosing a question', () => {
 
       beforeEach(async() => {
         const radios = await page.$$('input[type="radio"]');
@@ -135,7 +135,7 @@ describe('/question', () => {
 
     });
 
-    describe('if user clicks submit after choosing a question', () => {
+    describe('when user clicks submit after choosing a question', () => {
 
       let radios;
 


### PR DESCRIPTION
## What

Backfill test for identity and details pages.

## Why

To get automated assurance for this functionality.

## How

Adds `identity.spec.js` and `details.spec.js` with automation tests for question page content and validation.