### PR TITLE
FBISCC-56: backfill automation tests for query page validation

### DIFF
--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -7,14 +7,29 @@
     "maxlength": "Summary must be 2000 characters or fewer"
   },
   "applicant-name": {
-    "required": "Enter your full name"
+    "required": {
+      "identity": {
+        "Yes": "Enter the applicant's full name",
+        "No": "Enter your full name"
+      }
+    }
   },
   "email": {
-    "required": "Enter your email address",
+    "required": {
+      "identity": {
+        "Yes": "Enter the applicant's email address",
+        "No": "Enter your email address"
+      }
+    },
     "email": "Enter a valid email address"
   },
   "application-number": {
-    "required": "Enter your unique application number (UAN)",
+    "required": {
+      "identity": {
+        "Yes": "Enter the applicant's unique application number (UAN)",
+        "No": "Enter your unique application number (UAN)"
+      }
+    },
     "uan": "Enter a valid unique application number (UAN)"
   },
   "question": {

--- a/test/ui/04 - query/character-count.spec.js
+++ b/test/ui/04 - query/character-count.spec.js
@@ -6,14 +6,12 @@ describe('/query - character count', () => {
 
   describe('NFR-FOR-22 (FBISCC-44) - 2000 character query count limit', () => {
 
-    let radios;
-
     beforeEach(async() => {
       await page.goto(baseURL + '/landing');
       await submitPage();
 
       // select any question category and continue
-      radios = await page.$$('input[type="radio"]');
+      const radios = await page.$$('input[type="radio"]');
       await radios[0].click();
       await submitPage();
 

--- a/test/ui/04 - query/validation.spec.js
+++ b/test/ui/04 - query/validation.spec.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const config = require('../ui-test-config');
+
+describe('query - validation', () => {
+
+  beforeEach(async() => {
+    await page.goto(baseURL + '/landing');
+    await submitPage();
+
+    // select a question category that requires a UAN
+    const statusRadio = await page.$('input#question-status');
+    await statusRadio.click();
+    await submitPage();
+
+    // select 'No', not contacting us on behalf of somebody else, and continue
+    const no = await page.$('input#identity-No');
+    await no.click();
+    await submitPage();
+  });
+
+  describe('when user selects \'No\' on the identity page', () => {
+
+    describe('when user submits the query page without entering a query', () => {
+
+      it('should display an error message with text \'Enter details of the problem\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#email', config.validEmail);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter details of the problem');
+        expect(await errorMessages[0].innerText()).to.equal('Enter details of the problem');
+      });
+
+    });
+
+    describe('when user submits an email address with special characters in the user section', () => {
+
+      it('should not display an error for the email field', async() => {
+        await page.fill('#email', config.validEmailWithSpecialChars);
+
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+
+        expect(await page.url()).to.equal(baseURL + '/confirm');
+      });
+
+    });
+
+    describe('when user submits an invalid email address', () => {
+
+      it('should display an error message with text \'Enter a valid email address\'', async() => {
+        await page.fill('#email', config.invalidEmail);
+
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter a valid email address');
+        expect(await errorMessages[0].innerText()).to.equal('Enter a valid email address');
+      });
+
+    });
+
+    describe('when user submits an invalid UAN', () => {
+
+      it('should display an error message with text \'Enter a valid unique application number (UAN)\'', async() => {
+        await page.fill('#application-number', config.invalidUAN);
+
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#email', config.validEmail);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter a valid unique application number (UAN)');
+        expect(await errorMessages[0].innerText()).to.equal('Enter a valid unique application number (UAN)');
+      });
+
+    });
+
+    describe('when user submits the query page without a name', () => {
+
+      it('should display an error message with text \'Enter your full name\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#email', config.validEmail);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter your full name');
+        expect(await errorMessages[0].innerText()).to.equal('Enter your full name');
+      });
+
+    });
+
+    describe('when user submits the query page without an email', () => {
+
+      it('should display an error message with text \'Enter your email address\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter your email address');
+        expect(await errorMessages[0].innerText()).to.equal('Enter your email address');
+      });
+
+    });
+
+    describe('when user submits the query page without a UAN', () => {
+
+      it('should display an error message with text \'Enter your unique application number (UAN)\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#email', config.validEmail);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter your unique application number (UAN)');
+        expect(await errorMessages[0].innerText()).to.equal('Enter your unique application number (UAN)');
+      });
+
+    });
+
+  });
+
+  describe('when user selects \'Yes\' on the identity page', () => {
+
+    beforeEach(async() => {
+      await page.goto(baseURL + '/landing');
+      await submitPage();
+
+      // select a question category that requires a UAN
+      const statusRadio = await page.$('input#question-status');
+      await statusRadio.click();
+      await submitPage();
+
+      // select 'No', not contacting us on behalf of somebody else, and continue
+      const yes = await page.$('input#identity-Yes');
+      await yes.click();
+      await submitPage();
+
+      // complete the details page
+      await page.fill('#representative-name', config.validName);
+      await submitPage();
+    });
+
+    describe('when user submits the query page without a name', () => {
+
+      it('should display an error message with text \'Enter the applicant\'s name\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#email', config.validEmail);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s full name');
+        expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s full name');
+      });
+
+    });
+
+    describe('when user submits the query page without an email', () => {
+
+      it('should display an error message with text \'Enter the applicant\'s email address\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#application-number', config.validUAN);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s email address');
+        expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s email address');
+      });
+
+    });
+
+    describe('when user submits the query page without a UAN', () => {
+
+      // eslint-disable-next-line max-len
+      it('should display an error message with text \'Enter the applicant\'s unique application number (UAN)\'', async() => {
+        // populate other fields with valid inputs
+        await page.fill('#query', config.validQuery);
+        await page.fill('#applicant-name', config.validName);
+        await page.fill('#email', config.validEmail);
+
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s unique application number (UAN)');
+        expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s unique application number (UAN)');
+      });
+
+    });
+
+  });
+
+});

--- a/test/ui/ui-test-config.js
+++ b/test/ui/ui-test-config.js
@@ -1,13 +1,15 @@
 'use strict';
 
 module.exports = {
-  invalidEmail: '',
+  invalidEmail: 'invalid',
   validEmail: 'test@mail.com',
-  validEmailWithSpecialChars: '!£$%^$%£$(*&@mail.com',
+  validEmailWithSpecialChars: 'lennon&mccartney\'s-address@mail.com',
   validName: 'John Smith',
   // eslint-disable-next-line max-len
   invalidQuery: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibu',
   validQuery: 'I have forgotten my password and cannot view my immigration account details',
+  invalidUAN: '0000-1234-5678-9123',
+  validUAN: '3434-1234-5678-9123',
   notifyFailureEmail: 'perm-fail@simulator.notify',
   notifySuccessEmail: 'success@simulator.notify'
 };


### PR DESCRIPTION
## What
Backfill automation tests for query page validation. Includes query, name, email address, and UAN for both representative and applicant branches.

## Why
To provide automated assurance that the user is correctly prevented from submitting invalid fields and that they see the correct content depending on whether they are the applicant or a representative.

## How
Adds `validation.spec.js` file in the test/ui/query folder