### PR TITLE
FBISCC-17: add UI tests for feedback page

### DIFF
--- a/test/ui/07 - feedback/feedback.spec.js
+++ b/test/ui/07 - feedback/feedback.spec.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const config = require('../ui-test-config');
+
+describe.only('/feedback', () => {
+
+  describe('FR-FEE-1 (FBISCC-17) - service feedback page', () => {
+
+    describe('content', () => {
+
+      beforeEach(async() => {
+        await page.goto(baseURL + '/landing');
+        await page.waitForLoadState();
+        await page.click('a[href="/feedback"');
+        await page.waitForLoadState();
+      });
+
+      it('should include header with text \'Give feedback\'', async() => {
+        const header = await page.$('h1');
+        expect(await header.innerText()).to.equal('Give feedback');
+      });
+
+      it('should include five radio buttons with variable ratings', async() => {
+        const radios = await page.$$('input[type="radio"]');
+        const labels = await page.$$('.block-label');
+
+        expect(radios.length).to.equal(5);
+        expect(labels.length).to.equal(5);
+
+        expect(await labels[0].innerText()).to.equal('Very satisfied');
+        expect(await labels[1].innerText()).to.equal('Satisfied');
+        expect(await labels[2].innerText()).to.equal('Neither satisfied or dissatisfied');
+        expect(await labels[3].innerText()).to.equal('Dissatisfied');
+        expect(await labels[4].innerText()).to.equal('Very dissatisfied');
+      });
+
+      it('should include a textarea for written feedback with a hint', async() => {
+        const feedbackLabel = await page.$('#feedbackText-group .form-label');
+        const expectedLabel = 'Tell us how we could improve this service';
+        // eslint-disable-next-line max-len
+        const expectedHint = 'Do not include any personal information - for example, your unique application number (UAN)';
+
+        expect((await feedbackLabel.innerText()).includes(expectedLabel)).to.equal(true);
+        expect((await feedbackLabel.innerText()).includes(expectedHint)).to.equal(true);
+      });
+
+      it('should include an input field for the users email', async() => {
+        const labels = await page.$('.label-text');
+        const inputs = await page.$$('input[type="text"]');
+
+        expect(inputs.length).to.equal(1);
+        expect(await labels.innerText()).to.equal('Email address (optional)');
+      });
+
+    });
+
+    describe('field validation', () => {
+
+      describe('when the user attempts to send feedback with incorrect or missing fields', () => {
+
+        beforeEach(async() => {
+          await page.goto(baseURL + '/landing');
+          await page.waitForLoadState();
+          await page.click('a[href="/feedback"');
+          await page.waitForLoadState();
+        });
+
+        it('should not allow them to send feedback with no rating', async() => {
+          await page.fill('#feedbackText', config.validQuery);
+          await page.fill('#feedbackEmail', config.validEmail);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          const expected = 'Select how you feel about the service you received';
+
+          expect(await page.url()).to.equal(baseURL + '/feedback');
+          expect(errorSummaries.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal(expected);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorMessages[0].innerText()).to.equal(expected);
+        });
+
+        it('should not allow them to send feedback with no improvements', async() => {
+          const radios = await page.$$('input[type="radio"]');
+          await radios[0].click();
+          await page.fill('#feedbackEmail', config.validEmail);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          const expected = 'Enter feedback';
+
+          expect(await page.url()).to.equal(baseURL + '/feedback');
+          expect(errorSummaries.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal(expected);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorMessages[0].innerText()).to.equal(expected);
+        });
+
+        it('should not allow them to send feedback with an invalid email', async() => {
+          const radios = await page.$$('input[type="radio"]');
+          await radios[0].click();
+          await page.fill('#feedbackText', config.validQuery);
+          await page.fill('#feedbackEmail', config.invalidEmail);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          const expected = 'Enter a valid email address';
+
+          expect(await page.url()).to.equal(baseURL + '/feedback');
+          expect(errorSummaries.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal(expected);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorMessages[0].innerText()).to.equal(expected);
+        });
+
+        it('should allow them to send feedback with no email', async() => {
+          const radios = await page.$$('input[type="radio"]');
+          await radios[0].click();
+          await page.fill('#feedbackText', config.validQuery);
+          await submitPage();
+          // valid so page will be submitted page
+          expect(await page.url()).to.equal(baseURL + '/feedback-submitted');
+        });
+
+      });
+
+    });
+
+    describe('Sending feedback', () => {
+
+      describe('when the email sends successfully', () => {
+
+        beforeEach(async() => {
+          // Go to feedback page
+          await page.goto(baseURL + '/landing');
+          await page.waitForLoadState();
+          await page.click('a[href="/feedback"');
+          await page.waitForLoadState();
+
+          // Select radio button and input valid feedback text, mock email success and continue to next page
+          const radios = await page.$$('input[type="radio"]');
+          await radios[0].click();
+          await page.fill('#feedbackText', config.validQuery);
+          await page.fill('#feedbackEmail', config.notifySuccessEmail);
+          await submitPage();
+        });
+
+        it('should continue to the \'feedback-submitted\' page', async() => {
+          expect(await page.url()).to.equal(baseURL + '/feedback-submitted');
+        });
+
+      });
+
+      describe('when the email fails to send', () => {
+
+        beforeEach(async() => {
+          // Go to feedback page
+          await page.goto(baseURL + '/landing');
+          await page.waitForLoadState();
+          await page.click('a[href="/feedback"');
+          await page.waitForLoadState();
+
+          // Select radio button and input valid feedback text, mock email failure and attempt to continue to next page
+          const radios = await page.$$('input[type="radio"]');
+          await radios[0].click();
+          await page.fill('#feedbackText', config.validQuery);
+          await page.fill('#feedbackEmail', config.notifyFailureEmail);
+          await submitPage();
+        });
+
+        it('should stay on the \'feedback\' page', async() => {
+          expect(await page.url()).to.equal(baseURL + '/feedback');
+        });
+
+        it('should display the \'error\' template', async() => {
+          const h1 = await page.$('h1');
+          expect(await h1.innerText()).to.equal('Sorry, there is a problem with the service');
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/ui/07 - feedback/feedback.spec.js
+++ b/test/ui/07 - feedback/feedback.spec.js
@@ -2,25 +2,26 @@
 
 const config = require('../ui-test-config');
 
-describe.only('/feedback', () => {
+describe('/feedback', () => {
+
+  beforeEach(async() => {
+    // Go to feedback page
+    await page.goto(baseURL + '/landing');
+    await page.waitForLoadState();
+    await page.click('a[href="/feedback"');
+    await page.waitForLoadState();
+  });
 
   describe('FR-FEE-1 (FBISCC-17) - service feedback page', () => {
 
     describe('content', () => {
-
-      beforeEach(async() => {
-        await page.goto(baseURL + '/landing');
-        await page.waitForLoadState();
-        await page.click('a[href="/feedback"');
-        await page.waitForLoadState();
-      });
 
       it('should include header with text \'Give feedback\'', async() => {
         const header = await page.$('h1');
         expect(await header.innerText()).to.equal('Give feedback');
       });
 
-      it('should include five radio buttons with variable ratings', async() => {
+      it('should include five radio buttons with satisfaction ratings', async() => {
         const radios = await page.$$('input[type="radio"]');
         const labels = await page.$$('.block-label');
 
@@ -56,16 +57,9 @@ describe.only('/feedback', () => {
 
     describe('field validation', () => {
 
-      describe('when the user attempts to send feedback with incorrect or missing fields', () => {
+      describe('when the user attempts to send feedback without selecting a rating', () => {
 
-        beforeEach(async() => {
-          await page.goto(baseURL + '/landing');
-          await page.waitForLoadState();
-          await page.click('a[href="/feedback"');
-          await page.waitForLoadState();
-        });
-
-        it('should not allow them to send feedback with no rating', async() => {
+        it('should stay on the feedback page, display an error message and an error summary', async() => {
           await page.fill('#feedbackText', config.validQuery);
           await page.fill('#feedbackEmail', config.validEmail);
           await submitPage();
@@ -81,8 +75,11 @@ describe.only('/feedback', () => {
           expect(errorMessages.length).to.equal(1);
           expect(await errorMessages[0].innerText()).to.equal(expected);
         });
+      });
 
-        it('should not allow them to send feedback with no improvements', async() => {
+      describe('when the user attempts to send feedback without any improvements', async() => {
+
+        it('should stay on the feedback page, display an error message and an error summary', async() => {
           const radios = await page.$$('input[type="radio"]');
           await radios[0].click();
           await page.fill('#feedbackEmail', config.validEmail);
@@ -100,7 +97,11 @@ describe.only('/feedback', () => {
           expect(await errorMessages[0].innerText()).to.equal(expected);
         });
 
-        it('should not allow them to send feedback with an invalid email', async() => {
+      });
+
+      describe('when the user attempts to send feedback with an invalid email', async() => {
+
+        it('should stay on the feedback page, display an error message and an error summary', async() => {
           const radios = await page.$$('input[type="radio"]');
           await radios[0].click();
           await page.fill('#feedbackText', config.validQuery);
@@ -119,7 +120,11 @@ describe.only('/feedback', () => {
           expect(await errorMessages[0].innerText()).to.equal(expected);
         });
 
-        it('should allow them to send feedback with no email', async() => {
+      });
+
+      describe('when the user attempts to send feedback with no email', () => {
+
+        it('should continue to the feedback submitted page', async() => {
           const radios = await page.$$('input[type="radio"]');
           await radios[0].click();
           await page.fill('#feedbackText', config.validQuery);
@@ -132,17 +137,11 @@ describe.only('/feedback', () => {
 
     });
 
-    describe('Sending feedback', () => {
+    describe('when the user submits the feedback page with valid rating and text', () => {
 
       describe('when the email sends successfully', () => {
 
         beforeEach(async() => {
-          // Go to feedback page
-          await page.goto(baseURL + '/landing');
-          await page.waitForLoadState();
-          await page.click('a[href="/feedback"');
-          await page.waitForLoadState();
-
           // Select radio button and input valid feedback text, mock email success and continue to next page
           const radios = await page.$$('input[type="radio"]');
           await radios[0].click();
@@ -160,12 +159,6 @@ describe.only('/feedback', () => {
       describe('when the email fails to send', () => {
 
         beforeEach(async() => {
-          // Go to feedback page
-          await page.goto(baseURL + '/landing');
-          await page.waitForLoadState();
-          await page.click('a[href="/feedback"');
-          await page.waitForLoadState();
-
           // Select radio button and input valid feedback text, mock email failure and attempt to continue to next page
           const radios = await page.$$('input[type="radio"]');
           await radios[0].click();

--- a/test/ui/ui-test-config.js
+++ b/test/ui/ui-test-config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  invalidEmail: '',
+  invalidEmail: 'invalid',
   validEmail: 'test@mail.com',
   validEmailWithSpecialChars: '!£$%^$%£$(*&@mail.com',
   validName: 'John Smith',


### PR DESCRIPTION
## What
Add UI tests for Feedback page content, validation and sending feedback
## Why
To provide automated assurance that the user can view the feedback page and send feedback as expected
## How
adds feedback.spec.js to the test/ui/feedback folder