### PR TITLE
FBISCC-62 fix missing public files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ apps/*/translations/*
 .DS_Store
 apps/.DS_Store
 .nyc_output
+.env

--- a/kube/branch/deployment.yaml
+++ b/kube/branch/deployment.yaml
@@ -62,3 +62,12 @@ spec:
             limits:
               cpu: "100m"
               memory: "200Mi"
+          volumeMounts:
+            - mountPath: /public
+              name: public
+      volumes:
+        - name: public
+          emptyDir: {}
+        - name: configmap
+          configMap:
+            name: configmap

--- a/kube/dev/deployment.yaml
+++ b/kube/dev/deployment.yaml
@@ -62,3 +62,12 @@ spec:
             limits:
               cpu: "100m"
               memory: "200Mi"
+          volumeMounts:
+            - mountPath: /public
+              name: public
+      volumes:
+        - name: public
+          emptyDir: {}
+        - name: configmap
+          configMap:
+            name: configmap

--- a/kube/prod/deployment.yaml
+++ b/kube/prod/deployment.yaml
@@ -60,3 +60,12 @@ spec:
             limits:
               cpu: "400m"
               memory: "400Mi"
+          volumeMounts:
+            - mountPath: /public
+              name: public
+      volumes:
+        - name: public
+          emptyDir: {}
+        - name: configmap
+          configMap:
+            name: configmap

--- a/kube/stg/deployment.yaml
+++ b/kube/stg/deployment.yaml
@@ -67,3 +67,12 @@ spec:
             limits:
               cpu: "400m"
               memory: "400Mi"
+          volumeMounts:
+            - mountPath: /public
+              name: public
+      volumes:
+        - name: public
+          emptyDir: {}
+        - name: configmap
+          configMap:
+            name: configmap

--- a/kube/uat/deployment.yaml
+++ b/kube/uat/deployment.yaml
@@ -62,3 +62,12 @@ spec:
             limits:
               cpu: "200m"
               memory: "300Mi"
+          volumeMounts:
+            - mountPath: /public
+              name: public
+      volumes:
+        - name: public
+          emptyDir: {}
+        - name: configmap
+          configMap:
+            name: configmap


### PR DESCRIPTION
## What?
Add volumes to our kubernetes deployments

## Why?
* Some users have experienced issues where the `bundle.js` file isn't showing the public folder in an app.  This is usually used for clientside js
* At its core, a volume is just a directory, possibly with some data in it, which is accessible to the containers in a pod
* Hopefully, this fixes the issue of bundle.js not showing in the various environments such as dev, uat etc

## Testing?
Used the branch feature but it was working even without this deployment script 🤷‍♂️ 

## Screenshots 
<img width="1440" alt="Screenshot 2020-11-23 at 11 12 57" src="https://user-images.githubusercontent.com/12494656/99977126-2bec8100-2d9c-11eb-9b9b-8a5a661c81ce.png">

