### PR TITLE
docs: add windows setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,22 @@
 
 A [Home Office Forms (HOF)](https://ukhomeofficeforms.github.io/hof-guide/documentation/#getting-started) app for users to submit technical queries relating to the ID Check app, viewing or proving immigration status, or updating immigration account details. Queries are sent to support services for resolution using [GOV.UK Notify](https://www.notifications.service.gov.uk/).
 
-## Set up
+## Contents
+
+* [Linux and OSX set up](#linux-and-osx-set-up)
+    * [Set environment variables](#set-environment-variables)
+    * [Install pre-requisites](#install-prerequisites)
+    * [Run the app](#run-the-app)
+* [Windows set up](#windows-set-up)
+    * [Safely clone this repo](#safely-clone-this-repo)
+    * [Set environment variables](#set-environment-variables-1)
+    * [Install Docker Desktop for Windows](#install-docker-desktop-for-windows)
+    * [Run the app](#run-the-app-1)
+* [Test](#test)
+    * [Unit tests and linting](#unit-tests-and-linting)
+    * [Automated UI tests](#automated-ui-tests)
+
+## Linux and OSX set up
 
 ### Set environment variables
 
@@ -13,7 +28,7 @@ To run the app using the notprod Notify test service, you will need to:
 3. Get the test SRC casework email. This is the email address for `FBIS CCF Developers` on the [Notify service team](https://www.notifications.service.gov.uk/services/7c8d0248-51b8-4795-b920-3ff84efb7faf/users)
 4. Get the template ids from the [template page](https://www.notifications.service.gov.uk/services/7c8d0248-51b8-4795-b920-3ff84efb7faf/templates/837dc8ac-6abf-4f6a-9f0c-57a28ea7f43c)
 
-Then add the values retrieved above to your environment variables:
+Then add the values retrieved above to your bash profile:
 
 ```.env
 export NOTIFY_KEY=[API_KEY]
@@ -62,7 +77,7 @@ brew services start redis
 
 ### Run the app
 
-Any of the following commands will start the app. `npm run dev` starts the app in 'watch' mode, so it will update as you make code changes. `npm run debug` starts the app with Node dev tools available in the Chrome browser, accessible on the [Chrome inspect page](chrome://inspect/#devices).
+Any of the following commands will start the app, accessible at `localhost:8080`. `npm run dev` starts the app in 'watch' mode, so it will update as you make code changes. `npm run debug` starts the app with Node dev tools available in the Chrome browser, accessible on the [Chrome inspect page](chrome://inspect/#devices).
 
 ```bash
 npm start
@@ -76,7 +91,78 @@ To run the app using a mock Notify client (required for automated UI testing), u
 npm run start:mock
 ```
 
+## Windows set up
+
+On windows, it is recommended to run the app in a Docker container.
+
+### Safely clone this repo
+
+Before you clone this repo on windows, run the following command:
+
+```bash
+git config --global core.autocrlf false
+```
+
+This prevents git from replacing Unix line break characters with Windows line break characters when you clone the repo, because windows line breaks cause problems in Docker.
+
+If you have already cloned the repo, delete it, then run this command and clone it again.
+
+### Set environment variables
+
+To run the app using the notprod Notify test service, you will need to:
+
+1. Get the notprod API key securely from a colleague
+2. Ask a colleague to add you to the `Future Border and Immigration System Customer Contact Form - notprod` Notify service
+3. Get the test SRC casework email. This is the email address for `FBIS CCF Developers` on the [Notify service team](https://www.notifications.service.gov.uk/services/7c8d0248-51b8-4795-b920-3ff84efb7faf/users)
+4. Get the template ids from the [template page](https://www.notifications.service.gov.uk/services/7c8d0248-51b8-4795-b920-3ff84efb7faf/templates/837dc8ac-6abf-4f6a-9f0c-57a28ea7f43c)
+
+Search for 'environment variables' in the windows toolbar and click 'Edit the system environment variables'. In the System Properties dialogue, select 'Environment Variables'. Then, in the environment variable dialogue, add the following as system variables:
+
+```.env
+name NOTIFY_KEY         value [API_KEY]
+name SRC_CASEWORK_EMAIL value [FBIS_CCF_DEVELOPERS_EMAIL]
+name TEMPLATE_QUERY     value [QUERY_TEMPLATE_ID]
+name FEEBACK_EMAIL      value [FBIS_CCF_DEVELOPERS_EMAIL]
+name TEMPLATE_FEEDBACK  value [FEEDBACK_TEMPLATE_ID]
+```
+
+### Install Docker Desktop for Windows
+
+* [Install Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows/)
+* Restart your computer after installation
+* Run Docker Desktop
+* If prompted, [update the WSL 2 Linux kernel](https://docs.microsoft.com/en-gb/windows/wsl/wsl2-kernel)
+
+### Run the app
+
+With Docker desktop running, use the following command in the root directory to run the app:
+
+```bash
+docker-compose up -d
+```
+
+The app is ready to access on `localhost:8080` when you see logs like the following:
+
+```bash
+Creating fbis-ccf_redis_1 ... done
+Creating fbis-ccf_app_1 ... done
+Creating fbis-ccf_nginx-proxy_1 ... done
+```
+
+To stop the app, use following command:
+
+```bash
+docker-compose down
+```
+
+To re-build and run the app after pulling an update to the source code, use the following command:
+```bash
+docker-compose up -d --build --force-recreate
+```
+
 ## Test
+
+This test documentation assumes you are using Linux or OSX.
 
 ### Unit tests and linting
 


### PR DESCRIPTION
## What

Add windows setup instructions to README

## Why

So that users without unix-like operating systems can run the service locally, e.g. test engineers who may be on different equipment than developers