### PR TITLE
FBISCC-60: add test execution and coverage reports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,18 +5,6 @@ type: kubernetes
 
 steps:
 
-- name: unit-test
-  pull: if-not-exists
-  image: node
-  environment:
-    NOTIFY_KEY: UNIT_MOCK
-  commands:
-  - npm install
-  - npm test
-  when:
-    branch: [ master, development ]
-    event: push
-
 - name: redis-test-service
   pull: if-not-exists
   image: redis
@@ -25,13 +13,14 @@ steps:
     branch: [ master, development ]
     event: push
 
-- name: ui-test
+- name: test
   pull: if-not-exists
   image: mcr.microsoft.com/playwright:bionic
   environment:
-    NOTIFY_KEY: UI_MOCK
+    NOTIFY_KEY: USE_MOCK
   commands:
-    - npm install -s
+    - npm i -s && npm run build
+    - npm test
     - npm run test:ui:server
   when:
     branch: [ master, development ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ apps/*/translations/*
 apps/.DS_Store
 .nyc_output
 .env
+executions
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -290,6 +290,26 @@
         "kuler": "^2.0.0"
       }
     },
+    "@danmasta/mocha-sonar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@danmasta/mocha-sonar/-/mocha-sonar-1.0.0.tgz",
+      "integrity": "sha512-OKoXaCh3UTsX2GBCk519n6Yi+YaqdvjI1vmipISlcy+DnZ5d//Pn/BgiQ2+xVmf0Xe6hAc6gh3q3XFlRT1H/fA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19",
+        "mkdirp": "^1.0.4",
+        "mocha": "^8.1.0",
+        "xml-js": "^1.6.11"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
+    },
     "@hapi/hoek": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
@@ -8257,6 +8277,12 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -9784,6 +9810,15 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
       "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
+      "requires": {
+        "sax": "^1.2.4"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "license": "MIT",
+  "config": {
+    "reporter":"--reporter=@danmasta/mocha-sonar --reporter-options=reporter=spec,delimiter=--,output=executions"
+  },
   "scripts": {
     "start": "node app.js",
     "start:mock": "node app.js silent mock-notify",
@@ -7,12 +10,12 @@
     "debug": "node --inspect app.js",
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
-    "test:unit": "nyc mocha \"test/unit/**/*.spec.js\" --require test/test-helpers.js",
+    "test:unit": "nyc --reporter=lcov mocha \"test/unit/**/*.spec.js\" --require test/test-helpers.js -- $npm_package_config_reporter/unit.xml",
     "test:ui": "npm run test:ui:firefox && npm run test:ui:webkit && npm run test:ui:chromium",
     "test:ui:browser": "mocha \"test/ui/**/*.spec.js\" --require test/test-helpers.js test/ui/ui-test-helpers.js --timeout 10000",
-    "test:ui:chromium": "npm run test:ui:browser -- --browser-engine=chromium",
-    "test:ui:firefox": "npm run test:ui:browser -- --browser-engine=firefox",
-    "test:ui:webkit": "npm run test:ui:browser -- --browser-engine=webkit",
+    "test:ui:chromium": "npm run test:ui:browser -- --browser-engine=chromium $npm_package_config_reporter/chromium.xml",
+    "test:ui:firefox": "npm run test:ui:browser -- --browser-engine=firefox $npm_package_config_reporter/firefox.xml",
+    "test:ui:webkit": "npm run test:ui:browser -- --browser-engine=webkit $npm_package_config_reporter/webkit.xml",
     "test:ui:server": "start-server-and-test start:mock http://localhost:8080/landing?automation-test test:ui",
     "build": "hof-build",
     "postinstall": "npm run build"
@@ -26,6 +29,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@danmasta/mocha-sonar": "^1.0.0",
     "@types/chai": "^4.2.13",
     "@types/mocha": "^8.0.3",
     "@types/sinon": "^9.0.8",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.projectKey=fbis-ccf
 sonar.projectName=Future Border and Immigration System Customer Contact Form
 sonar.language=js
-sonar.sources=apps
-sonar.tests=test
+sonar.sources=apps,lib
+sonar.tests=test/unit,test/ui
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.testExecutionReportPaths=executions/unit.xml,executions/chromium.xml,executions/firefox.xml,executions/webkit.xml


### PR DESCRIPTION
## What

Add test execution and coverage reports after unit and UI test runs.

## Why

So that we can generate persistent reports in the sonar dashboard which can be used to inform and approve releases.

## How

A test coverage report is generated in `coverage/lcov.info` after unit test runs using [nyc](https://www.npmjs.com/package/nyc). Execution reports are generated in the `executions` directory, with separate reports for unit tests and UI tests across three browsers. Execution reports are generated with the [mocha-sonar](https://www.npmjs.com/package/@danmasta/mocha-sonar) package.