### PR TITLE
FBISCC-66: amend UAN regex to prevent ReDoS attacks

### DIFF
--- a/apps/fbis-ccf/validators/index.js
+++ b/apps/fbis-ccf/validators/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function uan(value) {
-  return typeof value === 'string' && !!value.match(/^(1212|3434)(-\d{4}){3}$/);
+  return typeof value === 'string' && !!value.match(/^(1212|3434)(-\d{4})(-\d{4})(-\d{4})$/);
 }
 
 module.exports = {


### PR DESCRIPTION
## What

Amend UAN validation regular expression to protect against [regular expression denial of service attacks](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS).

## Why

A sonar scan identified that the existing regular expression would be susceptible to this kind of attack.

## How

Tested a new regex using ReDoS checkers to ensure that it is not vulnerable, while also testing with existing UAN validation unit test suite to ensure it meets the business requirements.