### PR TITLE
FBISCC-63: Add new complete and feedback submitted pages

### DIFF
--- a/apps/fbis-ccf/behaviours/clear-session.js
+++ b/apps/fbis-ccf/behaviours/clear-session.js
@@ -3,7 +3,9 @@
 module.exports = superclass => class ClearSession extends superclass {
 
   getValues(req, res, next) {
+    const email = req.sessionModel.get('email');
     req.sessionModel.reset();
+    req.sessionModel.set('previousEmail', email);
     return super.getValues(req, res, next);
   }
 

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -44,8 +44,7 @@ module.exports = {
       next: '/complete'
     },
     '/complete': {
-      behaviours: [clearSession],
-      template: 'confirmation'
+      behaviours: [clearSession]
     }
   }
 };

--- a/apps/fbis-ccf/translations/src/en/pages.json
+++ b/apps/fbis-ccf/translations/src/en/pages.json
@@ -58,5 +58,16 @@
       "header": "Details of the problem"
     },
     "check-text": "Check the information you have entered is correct, and send your form."
+  },
+  "complete": {
+    "confirmation": "Form sent",
+    "message": "We have sent a confirmation email to",
+    "what-happens-next": {
+      "header": "What happens next",
+      "p1": "We've sent your enquiry to the online help team.",
+      "p2": "They will contact you within 5 working days with an answer to your problem, or to ask for more information.",
+      "a": "What did you think of this service?",
+      "hint": "(takes 30 seconds)"
+    }
   }
 }

--- a/apps/fbis-ccf/views/complete.html
+++ b/apps/fbis-ccf/views/complete.html
@@ -1,0 +1,7 @@
+{{<partials-page}}
+    {{$pageTitle}}{{#t}}pages.complete.confirmation{{/t}} - GOV.UK{{/pageTitle}}
+    {{$page-content}}
+        {{>partials-confirmation-alert}}
+        {{>partials-what-happens-next}}
+    {{/page-content}}
+{{/partials-page}}

--- a/apps/fbis-ccf/views/partials/confirmation-alert.html
+++ b/apps/fbis-ccf/views/partials/confirmation-alert.html
@@ -1,0 +1,7 @@
+<div class="alert-complete" role="alert">
+    <div class="alert-message">
+        <h1 id="confirm-heading" class="heading-xlarge">{{#t}}pages.complete.confirmation{{/t}}</h1>
+        <p id="confirm-text" class="font-large">{{#t}}pages.complete.message{{/t}}</p>
+        <p id="confirm-email" class="heading-large">{{values.previousEmail}}</p>
+    </div>
+</div>

--- a/apps/fbis-ccf/views/partials/what-happens-next.html
+++ b/apps/fbis-ccf/views/partials/what-happens-next.html
@@ -1,0 +1,6 @@
+<div id="what-happens-next">
+    <h2 id="next-heading" class="heading-medium">{{#t}}pages.complete.what-happens-next.header{{/t}}</h2>
+    <p>{{#t}}pages.complete.what-happens-next.p1{{/t}}</p>
+    <p>{{#t}}pages.complete.what-happens-next.p2{{/t}}</p>
+    <p><a href="/feedback">{{#t}}pages.complete.what-happens-next.a{{/t}}</a> {{#t}}pages.complete.what-happens-next.hint{{/t}}</p>
+</div>

--- a/apps/feedback/translations/src/en/pages.json
+++ b/apps/feedback/translations/src/en/pages.json
@@ -3,7 +3,7 @@
     "header": "Give feedback"
   },
   "feedback-submitted": {
-    "header": "Feedback submitted",
-    "confirmed": "Thank you"
+    "confirmation": "Feedback sent",
+    "return": "Return to form."
   }
 }

--- a/apps/feedback/views/feedback-submitted.html
+++ b/apps/feedback/views/feedback-submitted.html
@@ -1,9 +1,7 @@
 {{<partials-page}}
+    {{$pageTitle}}{{#t}}pages.feedback-submitted{{/t}} - GOV.UK{{/pageTitle}}
     {{$page-content}}
-        <h1 class="govuk-panel__title">
-            {{#t}}pages.feedback-submitted.confirmed{{/t}}
-        </h1>
-
-        {{#input-submit}}close{{/input-submit}}
+        <div id="complete-column">{{>partials-confirmation-alert}}</div>
+        <input  type="submit" value="{{#t}}pages.feedback-submitted.return{{/t}}" class="link">
     {{/page-content}}
 {{/partials-page}}

--- a/apps/feedback/views/partials/confirmation-alert.html
+++ b/apps/feedback/views/partials/confirmation-alert.html
@@ -1,0 +1,5 @@
+<div class="alert-complete" role="alert">
+    <div class="alert-message">
+        <h1 id="confirm-heading" class="heading-xlarge">{{#t}}pages.feedback-submitted.confirmation{{/t}}</h1>
+    </div>
+</div>

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,7 +1,14 @@
 // Custom styling for overriding HOF defaults as required by designs
 
-tr {
-  vertical-align: top;
+// Styles for form pages
+#identity-group {
+  .multiple-choice {
+    clear: right;
+    margin-right: 2em;
+  }
+  legend {
+    margin-bottom: 1em;
+  }
 }
 
 #query, #feedbackText {
@@ -13,20 +20,49 @@ tr {
   margin-bottom: 1em;
 }
 
-#identity-group {
-  .multiple-choice {
-    clear: right;
-    margin-right: 2em;
-  }
-  legend {
-    margin-bottom: 1em;
-  }
-}
-
+// Check your answers page styles
 .confirm-label {
   font-weight: bold;
 }
 
+tr {
+  vertical-align: top;
+}
+
+// Confirmation styles (complete & feedback submitted pages)
+#complete-column {
+  .alert-complete {
+    background-color: #00703C;
+    border-left: 0;
+    padding: 2em 30px;
+  }
+}
+
+#confirm-email {
+  margin: 0.2em 0 0 0;
+  word-wrap: break-word;
+}
+
+#confirm-heading {
+  margin: 0;
+}
+
+#confirm-text {
+  margin: 0.5em 0 0 0;
+}
+
+input[type="submit"].link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+#next-heading {
+  margin-top: 0;
+}
+
+// Wide display styles
 @media (min-width: 641px) {
   #query {
     height: 150px; // 6x default line-height for this screen width
@@ -38,5 +74,11 @@ tr {
 
   #applicant-phone, #organisation, #application-number {
     width: 67%;
+  }
+
+  #complete-column {
+    .alert-complete {
+      padding: 2em 40px;
+    }
   }
 }

--- a/test/ui/06 - complete/complete.spec.js
+++ b/test/ui/06 - complete/complete.spec.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const config = require('../ui-test-config');
+
+const setUp = async(question, identity, useOptionalFields, shouldSucceed) => {
+  await page.goto(baseURL + '/landing');
+  await submitPage();
+
+  // select a question category
+  const questionRadio = await page.$(`input#question-${question}`);
+  await questionRadio.click();
+  await submitPage();
+
+  // select identity
+  const identityRadio = await page.$(`input#identity-${identity}`);
+  await identityRadio.click();
+  await submitPage();
+
+  // complete details page if applicable
+  if (identity === 'Yes') {
+    await page.fill('#representative-name', config.validName);
+
+    // complete optional details fields if required
+    if (useOptionalFields) {
+      await page.fill('#representative-phone', '07000000000');
+      await page.fill('#organisation', 'Charity');
+    }
+
+    await submitPage();
+  }
+
+  // complete mandatory query fields
+  await page.fill('#query', config.validQuery);
+  await page.fill('#applicant-name', config.validName);
+  await page.fill('#email', shouldSucceed ? config.notifySuccessEmail : config.notifyFailureEmail);
+
+  // add UAN if required
+  if (question !== 'id-check') {
+    await page.fill('#application-number', config.validUAN);
+  }
+
+  // complete optional query fields if required
+  if (useOptionalFields) {
+    await page.fill('#applicant-phone', '07111111111');
+  }
+
+  await submitPage();
+  // submit query from 'check your answers' page
+  await submitPage();
+};
+
+describe('/complete', () => {
+
+  describe('FR-POS-11 (FBISCC-63) - Submission confirmation page', () => {
+
+    describe('when the user has successfully submitted their query and is viewing confirmation', () => {
+
+      beforeEach(async() => await setUp('id-check', 'No', false, true));
+
+      it('should include a header with text \'Form sent\'', async() => {
+        const header = await page.$('#confirm-heading');
+
+        expect(await header.innerText()).to.equal('Form sent');
+      });
+
+      it('should include text \'We have sent a confirmation email to [provided email]\'', async() => {
+        const text = await page.$('#confirm-text');
+        const email = await page.$('#confirm-email');
+
+        expect(await text.innerText()).to.equal('We have sent a confirmation email to');
+        expect(await email.innerText()).to.equal(config.notifySuccessEmail);
+      });
+
+      it('should include a section titled \'What happens next\'', async() => {
+        const nextSection = await page.$('#next-heading');
+        expect(await nextSection.innerText()).to.equal('What happens next');
+      });
+
+      it('should include a link to the feedback page with text \'What did you think of this service?\'', async() => {
+        const whatHappensNextPs = await page.$$('#what-happens-next > p');
+        const expected = '<a href="/feedback">What did you think of this service?</a>';
+        expect(await whatHappensNextPs[2].innerHTML()).to.include(expected);
+      });
+
+    });
+
+  });
+
+});

--- a/test/ui/07 - feedback/feedback-submitted.spec.js
+++ b/test/ui/07 - feedback/feedback-submitted.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// const config = require('../ui-test-config');
+
+describe('/feedback-submitted', () => {
+
+  beforeEach(async() => {
+    // Get to feedback submitted page
+    await page.goto(baseURL + '/landing');
+    await page.waitForLoadState();
+    await page.click('a[href="/feedback"');
+    await page.waitForLoadState();
+
+    const radio = await page.$('input[type="radio"]');
+    await radio.click();
+    await page.fill('#feedbackText', 'Feedback');
+    await submitPage();
+  });
+
+  describe('FR-FEE-1 (FBISCC-17) - service feedback page', () => {
+
+    describe('when the user has successfully submitted feedback and is viewing confirmation', () => {
+
+      it('should include a header with text \'Feedback sent\'', async() => {
+        const header = await page.$('#confirm-heading');
+        expect(await header.innerText()).to.equal('Feedback sent');
+      });
+
+      it('should include a link to return to the form with the text \'Return to form.\'', async() => {
+        const inputLink = await page.$('input[type="submit"]');
+        expect(await inputLink.getAttribute('value')).to.equal('Return to form.');
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/behaviours/clear-session.spec.js
+++ b/test/unit/behaviours/clear-session.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Behaviour = require('../../../apps/fbis-ccf/behaviours/clear-session');
+
+describe('Clear session behaviour', () => {
+
+  let req;
+  let res;
+  let ClearSession;
+  let testInstance;
+  let nextStub;
+
+  beforeEach(() => {
+    req = {
+      sessionModel: {
+        get: sinon.stub().withArgs('email').returns('test@mail.com'),
+        set: sinon.stub(),
+        reset: sinon.stub()
+      }
+    };
+    res = {};
+  });
+
+    describe('getValues', () => {
+
+      class Base {
+        getValues() {}
+      }
+
+      beforeEach(() => {
+        ClearSession = Behaviour(Base);
+        testInstance = new ClearSession();
+        nextStub = sinon.stub();
+      });
+
+      it('should reset the sessionModel', () => {
+        testInstance.getValues(req, res, nextStub);
+        expect(req.sessionModel.reset.calledOnce).to.equal(true);
+      });
+
+      it('should set previousEmail on the sessionModel to display on the confirmation page', () => {
+        testInstance.getValues(req, res, nextStub);
+        expect(req.sessionModel.set).to.be.calledOnceWith('previousEmail', 'test@mail.com');
+      });
+
+    });
+
+});


### PR DESCRIPTION
### What
Add new '/complete' and '/feedback-submitted' pages which are in line with design 
### How
Added new templates, partials and styling
### Why
To be more in line with design
### Test
Added UI tests in '06 - complete' and '07 - feedback'. Added tests for 'clear-session' behaviour.
### Screenshots
<img width="902" alt="Screenshot 2020-11-25 at 17 26 17" src="https://user-images.githubusercontent.com/61828376/100261906-56c50980-2f43-11eb-949f-8d08574fa55c.png">
<img width="855" alt="Screenshot 2020-11-25 at 17 26 49" src="https://user-images.githubusercontent.com/61828376/100261960-68a6ac80-2f43-11eb-9709-b2251e4a912a.png">

