### PR TITLE
FBISCC-69: update designs for representative-details page

### DIFF
--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -21,10 +21,12 @@ module.exports = {
     validate: ['required']
   },
   'application-number': {},
-  'representative-name': {
+  'representative-first-names': {
     validate: ['required']
   },
-  'representative-phone': {},
+  'representative-last-names': {
+    validate: ['required']
+  },
   organisation: {},
   email: {
     validate: ['required', 'email'],

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -36,7 +36,7 @@ module.exports = {
       }],
     },
     '/representative-details': {
-      fields: ['representative-name', 'representative-phone', 'organisation'],
+      fields: ['representative-first-names', 'representative-last-names', 'organisation'],
       next: '/contact-details'
     },
     '/contact-details': {

--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -44,17 +44,27 @@
     "label": "Unique application number - UAN (optional)",
     "hint": "For example, 3434-0000-0000-0001"
   },
-  "details": {
+  "representative-details": {
     "hint": "Details of the person filling out this form"
   },
-  "representative-name": {
-    "label": "Your full name"
+  "representative-first-names": {
+    "label": {
+      "in-UK": {
+        "true": "First names",
+        "false": "Given names"
+      }
+    }
   },
-  "representative-phone": {
-    "label": "Your phone number (optional)"
+  "representative-last-names": {
+    "label": {
+      "in-UK": {
+        "true": "Last names",
+        "false": "Family names"
+      }
+    }
   },
   "organisation": {
-    "label": "Your organisation's name (optional)"
+    "label": "Organisation name (optional)"
   },
   "email": {
     "label": "Email address"

--- a/apps/fbis-ccf/translations/src/en/pages.json
+++ b/apps/fbis-ccf/translations/src/en/pages.json
@@ -22,7 +22,7 @@
       }
     }
   },
-  "details": {
+  "representative-details": {
     "header": "Your details"
   },
   "contact-details": {

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -38,8 +38,21 @@
   "application-number": {
     "uan": "Enter a unique application number (UAN)"
   },
-  "representative-name": {
-    "required": "Enter your full name"
+  "representative-first-names": {
+    "required": {
+      "in-UK": {
+        "true": "Enter your first names",
+        "false": "Enter your given names"
+      }
+    }
+  },
+  "representative-last-names": {
+    "required": {
+      "in-UK": {
+        "true": "Enter your last names",
+        "false": "Enter your family names"
+      }
+    }
   },
   "query": {
     "required": "Enter details of the problem",

--- a/apps/fbis-ccf/views/representative-details.html
+++ b/apps/fbis-ccf/views/representative-details.html
@@ -1,7 +1,7 @@
 {{<step}}
     {{$page-content}}
        <label class="form-label">
-           <span id="representative-name-hint" class="form-hint">{{#t}}fields.details.hint{{/t}}</span>
+           <span id="representative-name-hint" class="form-hint">{{#t}}fields.representative-details.hint{{/t}}</span>
        </label>
         {{#fields}}
             {{#renderField}}{{/renderField}}

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -38,6 +38,7 @@
 
 #representative-name-hint {
   margin-bottom: 1em;
+  color: black;
 }
 
 // Check your answers page styles
@@ -88,12 +89,8 @@ input[type="submit"].link {
     height: 150px; // 6x default line-height for this screen width
   }
 
-  #applicant-first-names, #applicant-last-names, #email {
+  #applicant-first-names, #applicant-last-names, #email, #representative-first-names, #representative-last-names {
     width: 100%;
-  }
-
-  #representative-name, #representative-phone {
-    width: 80%;
   }
 
   #organisation, #application-number, #phone {

--- a/test/ui/v2/05 - representative-details/content.spec.js
+++ b/test/ui/v2/05 - representative-details/content.spec.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/* eslint max-len: off */
+
+const config = require('../../ui-test-config');
+
+const setUp = async(inUK, question, identity) => {
+  await page.goto(baseURL + '/question' + (inUK ? '' : '?outside-UK'));
+  // select a question category
+  const questionRadio = await page.$(`input#question-${question}`);
+  await questionRadio.click();
+  await submitPage();
+
+  // submit the context page, which requires no input
+  await submitPage();
+
+  // select identity
+  const identityRadio = await page.$(`input#identity-${identity}`);
+  await identityRadio.click();
+  await submitPage();
+
+  // fill applicant details
+  await page.fill('#applicant-first-names', config.validFirstNames);
+  await page.fill('#applicant-last-names', config.validLastNames);
+  await submitPage();
+};
+
+describe('/representative-details - content', () => {
+
+  describe('FR-REP-4 (FBISCC-69) - Representative details', () => {
+
+    describe('when the user accesses the service with the in-UK link', () => {
+
+      beforeEach(async() => await setUp(true, 'id-check', 'Yes'));
+
+      describe('when user inputs the applicants details and continues to the representative details page', () => {
+
+        it('should include a header with text \'Your details\'', async() => {
+          const header = await page.$('h1');
+          expect(await header.innerText()).to.equal('Your details');
+        });
+
+        it('should include a hint with text \'Details of person filling out this form\'', async() => {
+          const hint = await page.$('#representative-name-hint');
+          expect(await hint.innerText()).to.equal('Details of the person filling out this form');
+        });
+
+        it('should include three text input fields with labels \'First names\', \'Last names\' and \'Organisation (optional)\'', async() => {
+          const textInputs = await page.$$('input[type="text"]');
+          const labels = await page.$$('.form-group label');
+
+          expect(textInputs.length).to.equal(3);
+          expect(labels.length).to.equal(3);
+
+          expect(await labels[0].innerText()).to.equal('First names');
+          expect(await labels[1].innerText()).to.equal('Last names');
+          expect(await labels[2].innerText()).to.equal('Organisation name (optional)');
+        });
+
+      });
+
+    });
+
+    describe('when the user accesses the service with the outside-UK link', () => {
+
+      beforeEach(async() => await setUp(false, 'id-check', 'Yes'));
+
+      describe('when user inputs the applicants details and continues to the representative details page', () => {
+
+        it('should include three text input fields with the labels \'Given names\', \'Family names\' and \'Organisation (optional)\'', async() => {
+          const textInputs = await page.$$('input[type="text"]');
+          const labels = await page.$$('.form-group label');
+
+          expect(textInputs.length).to.equal(3);
+          expect(labels.length).to.equal(3);
+
+          expect(await labels[0].innerText()).to.equal('Given names');
+          expect(await labels[1].innerText()).to.equal('Family names');
+          expect(await labels[2].innerText()).to.equal('Organisation name (optional)');
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/ui/v2/05 - representative-details/validation.spec.js
+++ b/test/ui/v2/05 - representative-details/validation.spec.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/* eslint max-len: off */
+
+const config = require('../../ui-test-config');
+
+const setUp = async(inUK, question, identity) => {
+  await page.goto(baseURL + '/question' + (inUK ? '' : '?outside-UK'));
+  // select a question category
+  const questionRadio = await page.$(`input#question-${question}`);
+  await questionRadio.click();
+  await submitPage();
+
+  // submit the context page, which requires no input
+  await submitPage();
+
+  // select identity
+  const identityRadio = await page.$(`input#identity-${identity}`);
+  await identityRadio.click();
+  await submitPage();
+
+  // fill applicant details
+  await page.fill('#applicant-first-names', config.validFirstNames);
+  await page.fill('#applicant-last-names', config.validLastNames);
+  await submitPage();
+};
+
+describe('/representative-details - validation', () => {
+
+  describe('FR-FOR-21 (FBISCC-43) - Mandatory responses', () => {
+
+    describe('when the user accesses the service from the in-UK link', () => {
+
+      beforeEach(async() => setUp(true, 'id-check', 'Yes'));
+
+      describe('when the user submits the page without entering first names', () => {
+
+        it('should display an error message with text \'Enter your first names\'', async() => {
+          await page.fill('#representative-last-names', config.validLastNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your first names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your first names');
+        });
+
+      });
+
+      describe('when the user submits the page without entering last names', () => {
+
+        it('should display an error message with text \'Enter your last names\'', async() => {
+          await page.fill('#representative-first-names', config.validFirstNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your last names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your last names');
+        });
+
+      });
+
+      describe('when the user submits the page without entering an organisation', () => {
+
+        it('should continue to the contact-details page', async() => {
+          await page.fill('#representative-first-names', config.validFirstNames);
+          await page.fill('#representative-last-names', config.validLastNames);
+          await submitPage();
+
+          expect(await page.url()).to.equal(baseURL + '/contact-details');
+        });
+
+      });
+
+    });
+
+    describe('when the user accesses the service from the outside-UK link', () => {
+
+      beforeEach(async() => setUp(false, 'id-check', 'Yes'));
+
+      describe('when the user submits the page without entering given names', () => {
+
+        it('should display an error message with text \'Enter your given names\'', async() => {
+          await page.fill('#representative-last-names', config.validLastNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your given names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your given names');
+        });
+
+      });
+
+      describe('when the user submits the page without entering family names', () => {
+
+        it('should display an error message with text \'Enter your family names\'', async() => {
+          await page.fill('#representative-first-names', config.validFirstNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your family names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your family names');
+        });
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
### What
Updates '/representative-details' page to be in line with v5 designs.
### Why
To match designs that have been validated in research with users.
### How
Update field labels to match new desired inputs. Add validation to new fields. Add conditional field labels for inside/outside UK routes.
### Test
Added content.spec and validation.spec to 05 - representative details folder
### Screenshot
<img width="900" alt="Screenshot 2020-12-01 at 12 33 28" src="https://user-images.githubusercontent.com/61828376/100740964-6cb64c80-33d1-11eb-8102-f9d1f801570f.png">

