### PR TITLE
FBISCC-76: add updated service failure page

### DIFF
--- a/apps/common/translations/src/en/error.json
+++ b/apps/common/translations/src/en/error.json
@@ -1,11 +1,11 @@
 {
   "header": {
-    "problem": "Sorry, there is a problem with the service",
+    "problem": "Sorry, there is a problem with this service",
     "404": "Page not found"
   },
   "content": {
     "problem": {
-      "p1": "Try again later."
+      "p1": "Try again later or get help by phone on:"
     },
     "404": {
       "p1": "If you typed the web address, check it is correct.",

--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -3,11 +3,15 @@
     {{#t}}error.header.problem{{/t}}
   {{/header}}
   {{$content}}
-    <p>{{#t}}error.content.problem.p1{{/t}}</p>
-    {{#showStack}}
+    <div class="error">
+      <p id="help-by-phone">{{#t}}error.content.problem.p1{{/t}}</p>
+      {{>partials-phone-info}}
+      {{#showStack}}
+      <br>
       <pre>
         {{error.stack}}
       </pre>
-    {{/showStack}}
+      {{/showStack}}
+    </div>
   {{/content}}
 {{/partials-page}}

--- a/test/ui/08 - confirm/confirm.spec.js
+++ b/test/ui/08 - confirm/confirm.spec.js
@@ -364,7 +364,7 @@ describe('/confirm', () => {
 
       it('should display the \'error\' template', async() => {
         const h1 = await page.$('h1');
-        expect(await h1.innerText()).to.equal('Sorry, there is a problem with the service');
+        expect(await h1.innerText()).to.equal('Sorry, there is a problem with this service');
       });
 
     });

--- a/test/ui/10 - feedback/feedback.spec.js
+++ b/test/ui/10 - feedback/feedback.spec.js
@@ -6,7 +6,7 @@ describe('/feedback', () => {
 
   beforeEach(async() => {
     // Go to feedback page
-    await page.goto(baseURL + '/landing');
+    await page.goto(baseURL + '/question');
     await page.waitForLoadState();
     await page.click('a[href="/feedback"');
     await page.waitForLoadState();
@@ -173,7 +173,7 @@ describe('/feedback', () => {
 
         it('should display the \'error\' template', async() => {
           const h1 = await page.$('h1');
-          expect(await h1.innerText()).to.equal('Sorry, there is a problem with the service');
+          expect(await h1.innerText()).to.equal('Sorry, there is a problem with this service');
         });
 
       });

--- a/test/ui/10 - feedback/submitted.spec.js
+++ b/test/ui/10 - feedback/submitted.spec.js
@@ -4,7 +4,7 @@ describe('/feedback-submitted', () => {
 
   beforeEach(async() => {
     // Get to feedback submitted page
-    await page.goto(baseURL + '/landing');
+    await page.goto(baseURL + '/question');
     await page.waitForLoadState();
     await page.click('a[href="/feedback"');
     await page.waitForLoadState();

--- a/test/ui/11 - errors/problem-with-this-service.spec.js
+++ b/test/ui/11 - errors/problem-with-this-service.spec.js
@@ -1,1 +1,46 @@
 'use strict';
+
+const config = require('../ui-test-config');
+
+describe('Error - 500', () => {
+
+  describe('FR-ERR-29 (FBISCC-76) - \'Service failure\' error page', () => {
+
+    beforeEach(async() => {
+      // Go to feedback page
+      await page.goto(baseURL + '/question');
+      await page.waitForLoadState();
+      await page.click('a[href="/feedback"');
+      await page.waitForLoadState();
+
+      const radios = await page.$$('input[type="radio"]');
+      await radios[0].click();
+      await page.fill('#feedbackText', config.validQuery);
+      await page.fill('#feedbackEmail', config.notifyFailureEmail);
+      await submitPage();
+    });
+
+    it('should include a header with text \'Sorry, there is a problem with this service\'', async() => {
+      const header = await page.$('h1');
+      expect(await header.innerText()).to.equal('Sorry, there is a problem with this service');
+    });
+
+    it('should have a section to get help by phone', async() => {
+      const phoneSection = await page.$('#help-by-phone');
+      expect(await phoneSection.innerText()).to.equal('Try again later or get help by phone on:');
+    });
+
+    it('should have a section with times you can call', async() => {
+      const callInfo = await page.$$('.call-info');
+      expect(callInfo.length).to.equal(3);
+    });
+
+    it('should include a link with text \'Find out about call charges\'', async() => {
+      const callInfo = await page.$$('.call-info');
+      const expected = '<a href="https://www.gov.uk/call-charges" class="link">Find out about call charges</a>';
+      expect(await callInfo[2].innerHTML()).to.include(expected);
+    });
+
+  });
+
+});


### PR DESCRIPTION
### What
Add page for any 500 error - service failure
### Why
To bring app in line with new designs
### How
Edit content in `error` template
### Test
Add UI tests in `11 - errors`
### Screenshot
<img width="872" alt="Screenshot 2020-12-03 at 13 14 43" src="https://user-images.githubusercontent.com/61828376/101022607-85f20100-3569-11eb-8b57-a401185e5695.png">


