### PR TITLE
FBISCC-70: correct empty email validation message

### DIFF
--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -59,12 +59,7 @@
     "maxlength": "Summary must be 2000 characters or fewer"
   },
   "email": {
-    "required": {
-      "identity": {
-        "Yes": "Enter the applicant's email address",
-        "No": "Enter your email address"
-      }
-    },
+    "required": "Enter your email address",
     "email": "Enter a valid email address"
   },
   "question": {


### PR DESCRIPTION
## What

Correct empty email validation message in line with new designs

## Why

For consistency across the whole service

## How

Remove conditional branch for email address validation so that it always shows the same message, regardless of whether the user is the applicant or a representative.