### PR TITLE
FBISCC-64: Add html lang attribute to locals

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ app.use('/question', (req, res, next) => {
 });
 
 app.use((req, res, next) => {
+  res.locals.htmlLang = 'en';
   res.locals.feedbackUrl = '/feedback';
   next();
 });


### PR DESCRIPTION
### What
Set the html language to English
### Why
When this is not specified it causes an accessibility issue as screen readers need to know which language to use
### How
Add htmlLang attribute to res.locals in `index.js`
