### PR TITLE
FBISCC-83: add custom error page when form submission fails

### DIFF
--- a/apps/common/translations/src/en/error.json
+++ b/apps/common/translations/src/en/error.json
@@ -1,7 +1,8 @@
 {
   "header": {
     "problem": "Sorry, there is a problem with this service",
-    "404": "Page not found"
+    "404": "Page not found",
+    "not-sent": "Sorry, your form has not been sent"
   },
   "content": {
     "problem": {
@@ -17,6 +18,10 @@
       "p5": "Monday to Friday (excluding bank holidays), 8am to 8pm UK local time",
       "p6": "Saturday and Sunday, 9:30am to 4:30pm UK local time",
       "link": "Find out about call charges"
+    },
+    "not-sent": {
+      "link": "Try again using the online form",
+      "p1": "or get help by phone on:"
     }
   }
 }

--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -1,10 +1,20 @@
 {{<partials-page}}
   {{$header}}
-    {{#t}}error.header.problem{{/t}}
+    {{#error.formNotSubmitted}}
+      {{#t}}error.header.not-sent{{/t}}
+    {{/error.formNotSubmitted}}
+    {{^error.formNotSubmitted}}
+      {{#t}}error.header.problem{{/t}}
+    {{/error.formNotSubmitted}}
   {{/header}}
   {{$content}}
     <div class="error">
-      <p id="help-by-phone">{{#t}}error.content.problem.p1{{/t}}</p>
+      {{#error.formNotSubmitted}}
+        <p><a href="/question">{{#t}}error.content.not-sent.link{{/t}}</a> {{#t}}error.content.not-sent.p1{{/t}}</p>
+      {{/error.formNotSubmitted}}
+      {{^error.formNotSubmitted}}
+        <p id="help-by-phone">{{#t}}error.content.problem.p1{{/t}}</p>
+      {{/error.formNotSubmitted}}
       {{>partials-phone-info}}
       {{#showStack}}
       <br>

--- a/apps/fbis-ccf/behaviours/submit.js
+++ b/apps/fbis-ccf/behaviours/submit.js
@@ -92,6 +92,7 @@ module.exports = superclass => class Submit extends superclass {
       req.log('error', 'Error sending email to SRC casework address', `reference=${reference}`, err);
     }
     req.sessionModel.unset(notify.submitEmailReference);
+    err.formNotSubmitted = true;
     return next(err);
   }
 

--- a/test/ui/08 - confirm/confirm.spec.js
+++ b/test/ui/08 - confirm/confirm.spec.js
@@ -364,7 +364,7 @@ describe('/confirm', () => {
 
       it('should display the \'error\' template', async() => {
         const h1 = await page.$('h1');
-        expect(await h1.innerText()).to.equal('Sorry, there is a problem with this service');
+        expect(await h1.innerText()).to.equal('Sorry, your form has not been sent');
       });
 
     });

--- a/test/ui/11 - errors/form-not-submitted.spec.js
+++ b/test/ui/11 - errors/form-not-submitted.spec.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/* eslint max-len: off */
+
+const config = require('../ui-test-config');
+
+describe('Error - Form not submitted', () => {
+
+  beforeEach(async() => {
+    await page.goto(baseURL + '/question');
+
+    // select a question category
+    const questionRadio = await page.$('input#question-id-check');
+    await questionRadio.click();
+    await submitPage();
+
+    // submit the context page, which requires no input
+    await submitPage();
+
+    // select identity
+    const identityRadio = await page.$('input#identity-No');
+    await identityRadio.click();
+    await submitPage();
+
+    // fill applicant details
+    await page.fill('#applicant-first-names', config.validFirstNames);
+    await page.fill('#applicant-last-names', config.validLastNames);
+    await submitPage();
+
+    // fill contact details
+    await page.fill('#email', config.notifyFailureEmail);
+    await submitPage();
+
+    // enter query
+    await page.fill('#query', config.validQuery);
+    await submitPage();
+
+    // submit from confirm page
+    await submitPage();
+  });
+
+  describe('FR-ERR-29, (FBISCC-83) - \'Form not submitted\' error page', () => {
+
+    it('should include a header with text \'Sorry, your form has not been sent\'', async() => {
+      const header = await page.$('h1');
+      expect(await header.innerText()).to.equal('Sorry, your form has not been sent');
+    });
+
+    it('should include a link to try again', async() => {
+      const link = await page.$('.error a[href="/question"]');
+      expect(await link.innerText()).to.equal('Try again using the online form');
+    });
+
+    it('should have a section with times you can call', async() => {
+      const callInfo = await page.$$('.call-info');
+      expect(callInfo.length).to.equal(3);
+    });
+
+    it('should include a link with text \'Find out about call charges\'', async() => {
+      const callInfo = await page.$$('.call-info');
+      const expected = '<a href="https://www.gov.uk/call-charges" class="link">Find out about call charges</a>';
+      expect(await callInfo[2].innerHTML()).to.include(expected);
+    });
+
+  });
+
+});
+

--- a/test/unit/behaviours/submit.spec.js
+++ b/test/unit/behaviours/submit.spec.js
@@ -272,6 +272,16 @@ describe('Submit behaviour', () => {
           });
       });
 
+      it('should add formNotSubmitted flag to the error', () => {
+        const testError = new Error('testError');
+        mockUtils.sendEmail.rejects(testError);
+
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(testError.formNotSubmitted).to.equal(true);
+          });
+      });
+
       it('should unset the feedback email reference on the session if there is an error', () => {
         const testError = new Error('testError');
         mockUtils.sendEmail.rejects(testError);
@@ -339,6 +349,16 @@ describe('Submit behaviour', () => {
         return testInstance.saveValues(req, res, nextStub)
           .then(() => {
             expect(req.log.notCalled).to.equal(true);
+          });
+      });
+
+      it('should add formNotSubmitted flag to the error', () => {
+        const testError = new Error('testError');
+        mockUtils.pollEmailStatus.rejects(testError);
+
+        return testInstance.saveValues(req, res, nextStub)
+          .then(() => {
+            expect(testError.formNotSubmitted).to.equal(true);
           });
       });
 


### PR DESCRIPTION
### What
Add custom error page for when the form fails to send
### How
Add conditional rendering to the existing error page which is shown and hidden based on the sort of error
### Why
So the user knows their query has not been sent so they can contact by phone or redo the form
### Test
Add UI tests
