### PR TITLE
FBISCC-85: correct focus behaviour after radio button validation error

### DIFF
--- a/apps/common/views/partials/validation-summary.html
+++ b/apps/common/views/partials/validation-summary.html
@@ -1,0 +1,24 @@
+{{#errorlist.length}}
+<div class="validation-summary error-summary" tabindex="-1">
+  {{$errorlist-title}}
+
+    {{#errorLength.single}}
+      <h2>{{#t}}errorlist.title.single{{/t}}</h2>
+    {{/errorLength.single}}
+    {{#errorLength.multiple}}
+      <h2>{{#t}}errorlist.title.multiple{{/t}}</h2>
+    {{/errorLength.multiple}}
+
+  {{/errorlist-title}}
+
+  {{<partials-validation-list}}
+    {{$validation-list}}
+      {{#errorlist}}
+        {{#message}}
+          <li><a href="#{{#radioKey}}{{radioKey}}{{/radioKey}}{{^radioKey}}{{key}}{{/radioKey}}">{{ message }}</a></li>
+        {{/message}}
+      {{/errorlist}}
+    {{/validation-list}}
+  {{/partials-validation-list}}
+</div>
+{{/errorlist.length}}

--- a/apps/fbis-ccf/behaviours/set-radio-button-error-link.js
+++ b/apps/fbis-ccf/behaviours/set-radio-button-error-link.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const fields = require('../fields/index');
+
+module.exports = superclass => class SetRadioButtonErrorLink extends superclass {
+
+  errorHandler(err, req, res, next) {
+    const errFields = Object.keys(err);
+
+    errFields.forEach(field => {
+      if (fields[field].mixin === 'radio-group') {
+        err[field].radioKey = `${err[field].key}-${fields[field].options[0]}`;
+      }
+    });
+    return super.errorHandler(err, req, res, next);
+  }
+
+};

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -7,13 +7,14 @@ const handleIdentityChange = require('./behaviours/handle-identity-change');
 const handleQuestionChange = require('./behaviours/handle-question-change');
 const setLocationOnSession = require('./behaviours/set-location-on-session');
 const setQuestionFlagsOnValues = require('./behaviours/set-question-flags-on-values');
+const setRadioButtonErrorLink = require('./behaviours/set-radio-button-error-link');
 const submit = require('./behaviours/submit');
 
 module.exports = {
   name: 'fbis-ccf',
   steps: {
     '/question': {
-      behaviours: [setLocationOnSession, handleQuestionChange],
+      behaviours: [setLocationOnSession, setRadioButtonErrorLink, handleQuestionChange],
       fields: ['question'],
       next: '/context'
     },
@@ -22,7 +23,7 @@ module.exports = {
       next: '/identity',
     },
     '/identity': {
-      behaviours: [handleIdentityChange],
+      behaviours: [setRadioButtonErrorLink, handleIdentityChange],
       fields: ['identity'],
       next: '/applicant-details'
     },

--- a/test/unit/behaviours/set-radio-button-error-link.spec.js
+++ b/test/unit/behaviours/set-radio-button-error-link.spec.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const Behaviour = require('../../../apps/fbis-ccf/behaviours/set-radio-button-error-link');
+
+describe('Set radio button error link behaviour', () => {
+
+  let SetRadioButtonErrorLink;
+  let testInstance;
+  let nextStub;
+  const req = {};
+  const res = {};
+
+  describe('getValues', () => {
+
+    class Base {
+      errorHandler() {}
+    }
+
+    beforeEach(() => {
+      SetRadioButtonErrorLink = Behaviour(Base);
+      testInstance = new SetRadioButtonErrorLink();
+
+      nextStub = sinon.stub();
+    });
+
+    it('should set the error radioKey to \'question-id-check\' if the error field is question', () => {
+      const err = {
+        question: {
+          key: 'question'
+        }
+      };
+
+      const expected = {
+        question: {
+          key: 'question',
+          radioKey: 'question-id-check'
+        }
+      };
+
+      testInstance.errorHandler(err, req, res, nextStub);
+      expect(err).to.deep.equal(expected);
+    });
+
+    it('should set the error radioKey to \'identity-Yes\' if the error field is identity', () => {
+      const err = {
+        identity: {
+          key: 'identity'
+        }
+      };
+
+      const expected = {
+        identity: {
+          key: 'identity',
+          radioKey: 'identity-Yes'
+        }
+      };
+
+      testInstance.errorHandler(err, req, res, nextStub);
+      expect(err).to.deep.equal(expected);
+    });
+
+    it('should not set the radioKey if the error field is not a radio button', () => {
+      const err = {
+        query: {
+          key: 'query'
+        }
+      };
+
+      const expected = {
+        query: {
+          key: 'query',
+        }
+      };
+
+      testInstance.errorHandler(err, req, res, nextStub);
+      expect(err).to.deep.equal(expected);
+    });
+
+  });
+
+});


### PR DESCRIPTION
## What

Correct focus behaviour after validation errors on radio button fields.

## Why

So that keyboard users can more easily navigate to the radio button field where they have made an error.

## How

Set the validation summary list hrefs to the first option in a radio button group, when the error relates to a radio button here.