### PR TITLE
FBISCC-84: set CORS header to origin

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,6 +2,7 @@
 /* eslint no-process-env: 0 */
 
 module.exports = {
+  host: (process.env.HOST || 'localhost:8080'),
   notify: {
     apiKey: process.argv.some(arg => arg === 'mock-notify') ? 'UI_MOCK' : process.env.NOTIFY_KEY,
     feedbackEmailReference: 'feedback-email-reference',

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const hof = require('hof');
 const path = require('path');
 
 const settings = require('./hof.settings');
+const config = require('./config');
 
 settings.routes = settings.routes.map(route => require(route));
 settings.root = __dirname;
@@ -32,6 +33,8 @@ app.use('/question', (req, res, next) => {
 app.use((req, res, next) => {
   res.locals.htmlLang = 'en';
   res.locals.feedbackUrl = '/feedback';
+  res.header('Access-Control-Allow-Origin', config.host);
+  res.header('Vary', 'Origin');
   next();
 });
 

--- a/kube/branch/configmap.yaml
+++ b/kube/branch/configmap.yaml
@@ -13,3 +13,4 @@ data:
   TEMPLATE_QUERY: "f74ed86d-6d95-4e4a-88c8-b9875ed69b12"
   TEMPLATE_FEEDBACK: "837dc8ac-6abf-4f6a-9f0c-57a28ea7f43c"
   TEMPLATE_CONFIRMATION: "e7be8d4e-13fb-4d72-9b69-b03e1a824975"
+  HOST: "fbis-contact-form.branch.internal.sas-notprod.homeoffice.gov.uk"

--- a/kube/dev/configmap.yaml
+++ b/kube/dev/configmap.yaml
@@ -13,3 +13,4 @@ data:
   TEMPLATE_QUERY: "f74ed86d-6d95-4e4a-88c8-b9875ed69b12"
   TEMPLATE_FEEDBACK: "837dc8ac-6abf-4f6a-9f0c-57a28ea7f43c"
   TEMPLATE_CONFIRMATION: "e7be8d4e-13fb-4d72-9b69-b03e1a824975"
+  HOST: "fbis-contact-form.dev.internal.sas-notprod.homeoffice.gov.uk"

--- a/kube/prod/configmap.yaml
+++ b/kube/prod/configmap.yaml
@@ -13,3 +13,4 @@ data:
   TEMPLATE_QUERY: "c46a8521-7330-41a5-8afd-9e175a5c8360"
   TEMPLATE_FEEDBACK: "c215bef5-553a-4fe0-9d2d-379f4a695f05"
   TEMPLATE_CONFIRMATION: "6a925056-cbe9-4739-9e07-b15a1c677815"
+  HOST: "immigration-account-help.homeoffice.gov.uk"

--- a/kube/stg/configmap.yaml
+++ b/kube/stg/configmap.yaml
@@ -13,3 +13,4 @@ data:
   TEMPLATE_QUERY: "c46a8521-7330-41a5-8afd-9e175a5c8360"
   TEMPLATE_FEEDBACK: "c215bef5-553a-4fe0-9d2d-379f4a695f05"
   TEMPLATE_CONFIRMATION: "6a925056-cbe9-4739-9e07-b15a1c677815"
+  HOST: "fbis-contact-form.stg.internal.sas.homeoffice.gov.uk"

--- a/kube/uat/configmap.yaml
+++ b/kube/uat/configmap.yaml
@@ -13,3 +13,4 @@ data:
   TEMPLATE_QUERY: "f74ed86d-6d95-4e4a-88c8-b9875ed69b12"
   TEMPLATE_FEEDBACK: "837dc8ac-6abf-4f6a-9f0c-57a28ea7f43c"
   TEMPLATE_CONFIRMATION: "e7be8d4e-13fb-4d72-9b69-b03e1a824975"
+  HOST: "fbis-contact-form.uat.internal.sas-notprod.homeoffice.gov.uk"


### PR DESCRIPTION
### What
Set CORS header to origin
### How
Gets origin from configmap in each environment, sets it to an env var and sets the CORS header to it in `index.js`
### Why
To prevent web browser data loading
