### PR TITLE
FBISCC-85: add role alert to error summary list for screen readers

### DIFF
--- a/apps/common/views/partials/validation-summary.html
+++ b/apps/common/views/partials/validation-summary.html
@@ -1,12 +1,12 @@
 {{#errorlist.length}}
-<div class="validation-summary error-summary" tabindex="-1">
+<div class="validation-summary error-summary" tabindex="-1" aria-labelledby="error-summary-title" role="alert">
   {{$errorlist-title}}
 
     {{#errorLength.single}}
-      <h2>{{#t}}errorlist.title.single{{/t}}</h2>
+      <h2 id="error-summary-title">{{#t}}errorlist.title.single{{/t}}</h2>
     {{/errorLength.single}}
     {{#errorLength.multiple}}
-      <h2>{{#t}}errorlist.title.multiple{{/t}}</h2>
+      <h2 id="error-summary-title">{{#t}}errorlist.title.multiple{{/t}}</h2>
     {{/errorLength.multiple}}
 
   {{/errorlist-title}}


### PR DESCRIPTION
## What

Improve screen reader usability on error screens

## Why

So that screen reader users have the same information available to them as non screen reader users.

## How

Make error summary list aria-labelledby the 'There is a problem' header, give summary list role alert.