### PR TITLE
FBISCC-113: More control over user supplied input

### DIFF
--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -15,23 +15,25 @@ module.exports = {
     options: ['Yes', 'No']
   },
   'applicant-first-names': {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   'applicant-last-names': {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   'application-number': {},
   'representative-first-names': {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   'representative-last-names': {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   organisation: {},
   email: {
     validate: ['required', 'email'],
   },
-  'phone': {},
+  'phone': {
+    validate: ['numeric']
+  },
   query: {
     mixin: 'textarea',
     validate: ['required', { type: 'maxlength', arguments: 2000 }],

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -15,10 +15,42 @@
           }
         }
       }
+    },
+    "notUrl": {
+      "in-UK": {
+        "true": {
+          "identity": {
+            "Yes": "Enter the applicant's first names",
+            "No": "Enter your first names"
+          }
+        },
+        "false": {
+          "identity": {
+            "Yes": "Enter the applicant's given names",
+            "No": "Enter your given names"
+          }
+        }
+      }
     }
   },
   "applicant-last-names": {
     "required": {
+      "in-UK": {
+        "true": {
+          "identity": {
+            "Yes": "Enter the applicant's last names",
+            "No": "Enter your last names"
+          }
+        },
+        "false": {
+          "identity": {
+            "Yes": "Enter the applicant's family names",
+            "No": "Enter your family names"
+          }
+        }
+      }
+    },
+    "notUrl": {
       "in-UK": {
         "true": {
           "identity": {
@@ -44,10 +76,22 @@
         "true": "Enter your first names",
         "false": "Enter your given names"
       }
+    },
+    "notUrl": {
+      "in-UK": {
+        "true": "Enter your first names",
+        "false": "Enter your given names"
+      }
     }
   },
   "representative-last-names": {
     "required": {
+      "in-UK": {
+        "true": "Enter your last names",
+        "false": "Enter your family names"
+      }
+    },
+    "notUrl": {
       "in-UK": {
         "true": "Enter your last names",
         "false": "Enter your family names"
@@ -61,6 +105,9 @@
   "email": {
     "required": "Enter your email address",
     "email": "Enter a valid email address"
+  },
+  "phone": {
+    "numeric": "Enter a valid phone number"
   },
   "question": {
     "required": "Select what your problem is about"

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,17 +241,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-      "integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.10",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.10",
-        "@babel/types": "^7.12.10",
+        "@babel/code-frame": "^7.12.11",
+        "@babel/generator": "^7.12.11",
+        "@babel/helper-function-name": "^7.12.11",
+        "@babel/helper-split-export-declaration": "^7.12.11",
+        "@babel/parser": "^7.12.11",
+        "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -275,9 +275,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-      "integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -316,9 +316,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
       "dev": true
     },
     "@hapi/topo": {
@@ -430,16 +430,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/samsam": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
@@ -470,16 +460,16 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
       "dev": true,
       "optional": true
     },
     "@types/sinon": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.9.tgz",
-      "integrity": "sha512-z/y8maYOQyYLyqaOB+dYQ6i0pxKLOsfwCmHmn4T7jS/SDHicIslr37oE3Dg8SCqKrKeBy6Lemu7do2yy+unLrw==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.10.tgz",
+      "integrity": "sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==",
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
@@ -892,11 +882,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-code-frame": {
@@ -3623,22 +3613,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4332,9 +4309,9 @@
       }
     },
     "hof-form-controller": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/hof-form-controller/-/hof-form-controller-6.2.0.tgz",
-      "integrity": "sha512-YunPkUikyPRT9yp2IWqfw0y0WlcsGnv/Td2eZuvinPNd1znNKXyF836VuIlKYwP0rW7EiTAq2Z5Lz66gjv9oxg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/hof-form-controller/-/hof-form-controller-6.2.1.tgz",
+      "integrity": "sha512-HHQ1i5DXSIpdJtYSW8tIuMMntD5m6Qa5LuoUneQILEUpDZiArXLyQLwShyBAkRg66GZNACBGINhcPLjMAA2z7w==",
       "requires": {
         "debug": "^2.6.9",
         "deprecate": "^1.0.0",
@@ -4640,9 +4617,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -5361,11 +5338,11 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
-      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
-        "jws": "^3.1.4",
+        "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -5374,7 +5351,7 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "xtend": "^4.0.1"
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "ms": {
@@ -5859,16 +5836,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {
@@ -6775,12 +6752,12 @@
       }
     },
     "notifications-node-client": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-5.0.2.tgz",
-      "integrity": "sha512-HvCyfInQ045Tk0nibcAQdWfBy8wLSkSxvW0GWAAdTo+EFayFpqlKh1iLFJIaquqzjRQiN6hXDOez8l4dKQitBg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-5.1.0.tgz",
+      "integrity": "sha512-a3aoSZPHSc/8VaccfGvKKsIZ/crqbglP9dNvg0pHHTgWi6BYiJc+Md7wOPizzEPACa+SKdifs06VY8ktbTzySA==",
       "requires": {
-        "axios": "0.19.2",
-        "jsonwebtoken": "8.2.1",
+        "axios": "^0.21.1",
+        "jsonwebtoken": "^8.2.1",
         "underscore": "^1.9.0"
       }
     },
@@ -7501,9 +7478,9 @@
       }
     },
     "playwright": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.7.0.tgz",
-      "integrity": "sha512-yHf4lySomty4wtWetzXu71zswPOBMHnCqyeGM3dMRObuflyuIUWb0/U++hxZnwHCkyS1H8/1+93Rjq25Rz3IGw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.7.1.tgz",
+      "integrity": "sha512-dOSWME42wDedJ/PXv8k0zG0Kxd6d6R2OKA51/05++Z2ISdA4N58gHlWqlVKPDkBog1MI6lu/KNt7QDn19AybWQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -8752,14 +8729,13 @@
       }
     },
     "sinon": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.2.tgz",
-      "integrity": "sha512-9Owi+RisvCZpB0bdOVFfL314I6I4YoRlz6Isi4+fr8q8YQsDPoCe5UnmNtKHRThX3negz2bXHWIuiPa42vM8EQ==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.3.tgz",
+      "integrity": "sha512-m+DyAWvqVHZtjnjX/nuShasykFeiZ+nPuEfD4G3gpvKGkXRhkF/6NSt2qN2FjZhfrcHXFzUzI+NLnk+42fnLEw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/formatio": "^5.0.1",
         "@sinonjs/samsam": "^5.3.0",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
@@ -9034,9 +9010,9 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "start-server-and-test": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.11.6.tgz",
-      "integrity": "sha512-+0T83W/R7CVgIE2HJcrpJDleLt7Skc2Xj8jWWsItRGdpZwenAv0YtIpBEKoL64pwUtPAPoHuYUtvWUOfCRoVjg==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.11.7.tgz",
+      "integrity": "sha512-91hA8mddcHSS3R7xRrVS9FT4qdRDvHlOEbI+mAA/sAW+31e78ptFmWWj+PJHFUKJrxtIkQ3ZeejPxCdesktULg==",
       "dev": true,
       "requires": {
         "bluebird": "3.7.2",
@@ -9045,7 +9021,7 @@
         "execa": "3.4.0",
         "lazy-ass": "1.6.0",
         "ps-tree": "1.2.0",
-        "wait-on": "5.2.0"
+        "wait-on": "5.2.1"
       },
       "dependencies": {
         "debug": {
@@ -9803,9 +9779,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
-      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.5.tgz",
+      "integrity": "sha512-48z9VGWwdCV5KfizHsE05DWS5fhK6gFlx5MjO7xu0Krc5FGPWzjlXEVV0nPMrdVuP7xmMHiPZ2HoYZwKOFTZOg=="
     },
     "urix": {
       "version": "0.1.0",
@@ -9904,16 +9880,16 @@
       }
     },
     "wait-on": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.0.tgz",
-      "integrity": "sha512-U1D9PBgGw2XFc6iZqn45VBubw02VsLwnZWteQ1au4hUVHasTZuFSKRzlTB2dqgLhji16YVI8fgpEpwUdCr8B6g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.1.tgz",
+      "integrity": "sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==",
       "dev": true,
       "requires": {
-        "axios": "^0.19.2",
-        "joi": "^17.1.1",
-        "lodash": "^4.17.19",
+        "axios": "^0.21.1",
+        "joi": "^17.3.0",
+        "lodash": "^4.17.20",
         "minimist": "^1.2.5",
-        "rxjs": "^6.5.5"
+        "rxjs": "^6.6.3"
       }
     },
     "which": {
@@ -10089,9 +10065,9 @@
       }
     },
     "ws": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
       "dev": true
     },
     "x-xss-protection": {

--- a/test/ui/04 - applicant-details/validation.spec.js
+++ b/test/ui/04 - applicant-details/validation.spec.js
@@ -68,6 +68,44 @@ describe('/applicant-details - validation', () => {
 
         });
 
+        describe('when user submits the page with a URL in the \'first names\' field', () => {
+
+          it('should display an error message with text \'Enter your first names\'', async() => {
+            await page.fill('#applicant-first-names', 'www.test.com');
+            await page.fill('#applicant-last-names', config.validLastNames);
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter your first names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter your first names');
+          });
+
+        });
+
+        describe('when user submits the page with a URL in the \'last names\' field', () => {
+
+          it('should display an error message with text \'Enter your last names\'', async() => {
+            await page.fill('#applicant-first-names', config.validFirstNames);
+            await page.fill('#applicant-last-names', 'www.test.com');
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter your last names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter your last names');
+          });
+
+        });
+
       });
 
       describe('when user selects \'Yes\' on the identity page', () => {
@@ -98,6 +136,44 @@ describe('/applicant-details - validation', () => {
           it('should display an error message with text \'Enter the applicant\'s last names\'', async() => {
             // populate other fields with valid inputs
             await page.fill('#applicant-first-names', config.validFirstNames);
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s last names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s last names');
+          });
+
+        });
+
+        describe('when user submits the page with a URL in the \'first names\' field', () => {
+
+          it('should display an error message with text \'Enter the applicant\'s first names\'', async() => {
+            await page.fill('#applicant-first-names', 'www.test.com');
+            await page.fill('#applicant-last-names', config.validLastNames);
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s first names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s first names');
+          });
+
+        });
+
+        describe('when user submits the page with a URL in the \'last names\' field', () => {
+
+          it('should display an error message with text \'Enter the applicant\'s last names\'', async() => {
+            await page.fill('#applicant-first-names', config.validFirstNames);
+            await page.fill('#applicant-last-names', 'www.test.com');
 
             await submitPage();
 
@@ -160,13 +236,51 @@ describe('/applicant-details - validation', () => {
 
         });
 
+        describe('when user submits the page with a URL in the \'given names\' field', () => {
+
+          it('should display an error message with text \'Enter your given names\'', async() => {
+            await page.fill('#applicant-first-names', 'www.test.com');
+            await page.fill('#applicant-last-names', config.validLastNames);
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter your given names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter your given names');
+          });
+
+        });
+
+        describe('when user submits the page with a URL in the \'family names\' field', () => {
+
+          it('should display an error message with text \'Enter your family names\'', async() => {
+            await page.fill('#applicant-first-names', config.validFirstNames);
+            await page.fill('#applicant-last-names', 'www.test.com');
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter your family names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter your family names');
+          });
+
+        });
+
       });
 
       describe('when user selects \'Yes\' on the identity page', () => {
 
         beforeEach(async() => setUp(false, 'id-check', 'Yes'));
 
-        describe('when user submits the page without entering first names', () => {
+        describe('when user submits the page without entering given names', () => {
 
           it('should display an error message with text \'Enter the applicant\'s given names\'', async() => {
             // populate other fields with valid inputs
@@ -185,11 +299,49 @@ describe('/applicant-details - validation', () => {
 
         });
 
-        describe('when user submits the page without entering last names', () => {
+        describe('when user submits the page without entering family names', () => {
 
           it('should display an error message with text \'Enter the applicant\'s family names\'', async() => {
             // populate other fields with valid inputs
             await page.fill('#applicant-first-names', config.validFirstNames);
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s family names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s family names');
+          });
+
+        });
+
+        describe('when user submits the page with a URL in the \'given names\' field', () => {
+
+          it('should display an error message with text \'Enter the applicant\'s given names\'', async() => {
+            await page.fill('#applicant-first-names', 'www.test.com');
+            await page.fill('#applicant-last-names', config.validLastNames);
+
+            await submitPage();
+
+            const errorSummaries = await getErrorSummaries();
+            const errorMessages = await getErrorMessages();
+
+            expect(errorSummaries.length).to.equal(1);
+            expect(errorMessages.length).to.equal(1);
+            expect(await errorSummaries[0].innerText()).to.equal('Enter the applicant\'s given names');
+            expect(await errorMessages[0].innerText()).to.equal('Enter the applicant\'s given names');
+          });
+
+        });
+
+        describe('when user submits the page with a URL in the \'family names\' field', () => {
+
+          it('should display an error message with text \'Enter the applicant\'s family names\'', async() => {
+            await page.fill('#applicant-first-names', config.validFirstNames);
+            await page.fill('#applicant-last-names', 'www.test.com');
 
             await submitPage();
 

--- a/test/ui/05 - representative-details/validation.spec.js
+++ b/test/ui/05 - representative-details/validation.spec.js
@@ -67,6 +67,42 @@ describe('/representative-details - validation', () => {
 
       });
 
+      describe('when the user submits the page with a URL in the \'first names\' field', () => {
+
+        it('should display an error message with text \'Enter your first names\'', async() => {
+          await page.fill('#representative-first-names', 'www.test.com');
+          await page.fill('#representative-last-names', config.validLastNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your first names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your first names');
+        });
+
+      });
+
+      describe('when the user submits the page with a URL in the \'last names\' field', () => {
+
+        it('should display an error message with text \'Enter your first names\'', async() => {
+          await page.fill('#representative-first-names', config.validFirstNames);
+          await page.fill('#representative-last-names', 'www.test.com');
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your last names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your last names');
+        });
+
+      });
+
       describe('when the user submits the page without entering an organisation', () => {
 
         it('should continue to the contact-details page', async() => {
@@ -106,6 +142,42 @@ describe('/representative-details - validation', () => {
 
         it('should display an error message with text \'Enter your family names\'', async() => {
           await page.fill('#representative-first-names', config.validFirstNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your family names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your family names');
+        });
+
+      });
+
+      describe('when the user submits the page with a URL in the \'given names\' field', () => {
+
+        it('should display an error message with text \'Enter your given names\'', async() => {
+          await page.fill('#representative-first-names', 'www.test.com');
+          await page.fill('#representative-last-names', config.validLastNames);
+          await submitPage();
+
+          const errorSummaries = await getErrorSummaries();
+          const errorMessages = await getErrorMessages();
+
+          expect(errorSummaries.length).to.equal(1);
+          expect(errorMessages.length).to.equal(1);
+          expect(await errorSummaries[0].innerText()).to.equal('Enter your given names');
+          expect(await errorMessages[0].innerText()).to.equal('Enter your given names');
+        });
+
+      });
+
+      describe('when the user submits the page with a URL in the \'family names\' field', () => {
+
+        it('should display an error message with text \'Enter your family names\'', async() => {
+          await page.fill('#representative-first-names', config.validFirstNames);
+          await page.fill('#representative-last-names', 'www.test.com');
           await submitPage();
 
           const errorSummaries = await getErrorSummaries();

--- a/test/ui/06 - contact-details/contact-details.spec.js
+++ b/test/ui/06 - contact-details/contact-details.spec.js
@@ -87,6 +87,24 @@ describe('/contact-details', () => {
 
     });
 
+    describe('when the user submits the page with text in the phone field', () => {
+
+      it('should display an error message with text \'Enter a valid phone number\'', async() => {
+        await page.fill('#email', config.validEmail);
+        await page.fill('#phone', 'Text');
+        await submitPage();
+
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter a valid phone number');
+        expect(await errorMessages[0].innerText()).to.equal('Enter a valid phone number');
+      });
+
+    });
+
   });
 
   describe('FR-VAL-8 (FBISCC-32) - Email address validation', () => {


### PR DESCRIPTION
### What
Add new 'notUrl' validator to name fields and 'numeric' validator to phone field to ensure no malicious information can be provided. Add new translation for the new validation errors.
### Why
The security architects from the ITHC raised concern that malicious links could be provided in the name columns to trick users or caseworkers into clicking on them. This fix ensures this cannot happen.
### How
New notUrl validator doesn't allow links to be provided in the name fields. Numeric validator on phone also ensures links can't be provided
### Test
Added UI tests for the new validation errors that arise.
### Screenshots
<img width="948" alt="Screenshot 2021-01-07 at 13 44 00" src="https://user-images.githubusercontent.com/61828376/103899508-690f9700-50ee-11eb-87db-cf5541ba3326.png">

<img width="767" alt="Screenshot 2021-01-07 at 13 44 33" src="https://user-images.githubusercontent.com/61828376/103899563-7af13a00-50ee-11eb-833a-14f41f2fc7d7.png">

