### PR TITLE
FBISCC-113: Update phone validator and translations for error message

### DIFF
--- a/apps/fbis-ccf/fields/index.js
+++ b/apps/fbis-ccf/fields/index.js
@@ -32,7 +32,7 @@ module.exports = {
     validate: ['required', 'email'],
   },
   'phone': {
-    validate: ['numeric']
+    validate: ['internationalPhoneNumber']
   },
   query: {
     mixin: 'textarea',

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -107,7 +107,7 @@
     "email": "Enter a valid email address"
   },
   "phone": {
-    "numeric": "Enter a valid phone number"
+    "internationalPhoneNumber": "Enter a valid phone number"
   },
   "question": {
     "required": "Select what your problem is about"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4309,9 +4309,9 @@
       }
     },
     "hof-form-controller": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/hof-form-controller/-/hof-form-controller-6.2.1.tgz",
-      "integrity": "sha512-HHQ1i5DXSIpdJtYSW8tIuMMntD5m6Qa5LuoUneQILEUpDZiArXLyQLwShyBAkRg66GZNACBGINhcPLjMAA2z7w==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/hof-form-controller/-/hof-form-controller-6.2.2.tgz",
+      "integrity": "sha512-VFNptOJAfjbfQdDkFNrwiPMGBjnZrvdMe8V0HokZ8OtR5LMsy2IVPtFyvgS9xgHfbF/zYyMZ8MZIiHjcsZibxA==",
       "requires": {
         "debug": "^2.6.9",
         "deprecate": "^1.0.0",
@@ -5441,9 +5441,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.6.tgz",
-      "integrity": "sha512-Ob419L88HxP3iVXPMI1Z/146izHrUPcV70ClnoP9WyNBgdy6mtlkCxx4ewMDmCzsdY5D4diDOUz8kboqLdKBoQ=="
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.7.tgz",
+      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw=="
     },
     "load-json-file": {
       "version": "1.1.0",


### PR DESCRIPTION
### What
Update hof-form-controller version to capture fixed phone validator, remove old validator from phone field.
### Why
To allow us to validate for phone numbers
