### PR TITLE
FBISCC-114

### DIFF
--- a/apps/feedback/behaviours/clear-feedback.js
+++ b/apps/feedback/behaviours/clear-feedback.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const notify = require('../../../config').notify;
 
 module.exports = superclass => class ClearFeedback extends superclass {
@@ -8,8 +7,7 @@ module.exports = superclass => class ClearFeedback extends superclass {
     req.sessionModel.unset([
       'feedbackRating',
       'feedbackText',
-      'feedbackEmail',
-      notify.feedbackEmailReference
+      'feedbackEmail'
     ]);
 
     return super.getValues(req, res, next);
@@ -17,7 +15,7 @@ module.exports = superclass => class ClearFeedback extends superclass {
 
   successHandler(req, res) {
     const referer = req.sessionModel.get('feedbackReturnTo') || `${req.get('origin')}/question`;
-    req.sessionModel.unset('feedbackReturnTo');
+    req.sessionModel.unset(['feedbackReturnTo', notify.feedbackEmailReference]);
     return res.redirect(referer);
   }
 

--- a/test/unit/behaviours/clear-feedback.spec.js
+++ b/test/unit/behaviours/clear-feedback.spec.js
@@ -51,8 +51,7 @@ describe('Clear feedback behaviour', () => {
       expect(req.sessionModel.unset).to.have.been.calledOnceWith([
         'feedbackRating',
         'feedbackText',
-        'feedbackEmail',
-        mockConfig.notify.feedbackEmailReference]);
+        'feedbackEmail']);
     });
 
   });
@@ -75,9 +74,12 @@ describe('Clear feedback behaviour', () => {
       expect(res.redirect).to.be.calledOnceWith('example-link.com/question');
     });
 
-    it('should unset the feedbackReturnTo link on the session', () => {
+    it('should unset the feedbackReturnTo link and feedbackEmailReference on the session', () => {
       testInstance.successHandler(req, res);
-      expect(req.sessionModel.unset).to.be.calledOnceWith('feedbackReturnTo');
+      expect(req.sessionModel.unset).to.be.calledOnceWith([
+        'feedbackReturnTo',
+        mockConfig.notify.feedbackEmailReference
+      ]);
     });
 
     it('should redirect the user to the link they came from', () => {


### PR DESCRIPTION
Amended behaviour where feedBackEmailReference was cleared after every email send, now clears when the user returns to the form

Ammended clear-feedback-spec to reflect this change

A user was able to spam post requests to the API to flood the CCF inbox with emails. Amending this behaviour means that each session will only be able to send one email per feedback session