### PR TITLE
FBISCC-156: make UAN required and update tests

### DIFF
--- a/apps/fbis-ccf/behaviours/add-location-to-backlink.js
+++ b/apps/fbis-ccf/behaviours/add-location-to-backlink.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 module.exports = superclass => class AddLocationToBacklink extends superclass {
 
   locals(req, res) {

--- a/apps/fbis-ccf/behaviours/add-uan-validator-if-required.js
+++ b/apps/fbis-ccf/behaviours/add-uan-validator-if-required.js
@@ -8,7 +8,7 @@ module.exports = superclass => class AddUANValidatorIfRequired extends superclas
     const isUANRequired = req.sessionModel.get('question') !== 'id-check';
 
     if (isUANRequired) {
-      req.form.options.fields['application-number'].validate = [customValidators.uan];
+      req.form.options.fields['application-number'].validate = [customValidators.uan, 'required'];
     }
 
     return super.process(req, res, next);

--- a/apps/fbis-ccf/behaviours/disable-backlink-on-edit.js
+++ b/apps/fbis-ccf/behaviours/disable-backlink-on-edit.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = superclass => class disableBacklinkOnEdit extends superclass {
+
+  locals(req, res) {
+    let locals = super.locals(req, res);
+
+    const isChangeLinkEdit = req.url.includes('/edit');
+
+    if (!isChangeLinkEdit) {
+      return locals;
+    }
+
+    locals.backLink = false;
+
+    return locals;
+  }
+
+};

--- a/apps/fbis-ccf/behaviours/handle-identity-change.js
+++ b/apps/fbis-ccf/behaviours/handle-identity-change.js
@@ -21,7 +21,7 @@ module.exports = superclass => class HandleIdentityChange extends superclass {
 
     if (previousIdentity === 'No' && newIdentity === 'Yes') {
       req.sessionModel.set('identity', newIdentity);
-      return res.redirect(`${req.get('origin')}/representative-details/edit`);
+      return res.redirect('/representative-details/edit');
     }
 
     return super.saveValues(req, res, next);

--- a/apps/fbis-ccf/behaviours/handle-question-change.js
+++ b/apps/fbis-ccf/behaviours/handle-question-change.js
@@ -16,6 +16,11 @@ module.exports = superclass => class HandleQuestionChange extends superclass {
       req.sessionModel.set('application-number', '');
     }
 
+    if (previousQuestion === 'id-check' && newQuestion !== 'id-check') {
+      req.sessionModel.set('question', newQuestion);
+      return res.redirect('/applicant-details/edit');
+    }
+
     return super.saveValues(req, res, next);
   }
 

--- a/apps/fbis-ccf/index.js
+++ b/apps/fbis-ccf/index.js
@@ -3,6 +3,7 @@
 const addLocationToBacklink = require('./behaviours/add-location-to-backlink');
 const addUANValidatorIfRequired = require('./behaviours/add-uan-validator-if-required');
 const clearSession = require('./behaviours/clear-session');
+const disableBacklinkOnEdit = require('./behaviours/disable-backlink-on-edit');
 const handleIdentityChange = require('./behaviours/handle-identity-change');
 const handleQuestionChange = require('./behaviours/handle-question-change');
 const setLocationOnSession = require('./behaviours/set-location-on-session');
@@ -20,7 +21,7 @@ module.exports = {
     },
     '/context': {
       behaviours: [addLocationToBacklink, setQuestionFlagsOnValues],
-      next: '/identity',
+      next: '/identity'
     },
     '/identity': {
       behaviours: [setRadioButtonErrorLink, handleIdentityChange],
@@ -28,7 +29,7 @@ module.exports = {
       next: '/applicant-details'
     },
     '/applicant-details': {
-      behaviours: [setQuestionFlagsOnValues, addUANValidatorIfRequired],
+      behaviours: [setQuestionFlagsOnValues, addUANValidatorIfRequired, disableBacklinkOnEdit],
       fields: ['applicant-first-names', 'applicant-last-names', 'application-number'],
       next: '/contact-details',
       forks: [{
@@ -40,6 +41,7 @@ module.exports = {
       }],
     },
     '/representative-details': {
+      behaviours: [disableBacklinkOnEdit],
       fields: ['representative-first-names', 'representative-last-names', 'organisation'],
       next: '/contact-details'
     },

--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -41,7 +41,7 @@
     }
   },
   "application-number": {
-    "label": "Unique application number - UAN (optional)",
+    "label": "Unique application number - UAN",
     "hint": "For example, 3434-0000-0000-0001"
   },
   "representative-details": {

--- a/apps/fbis-ccf/translations/src/en/validation.json
+++ b/apps/fbis-ccf/translations/src/en/validation.json
@@ -68,7 +68,8 @@
     }
   },
   "application-number": {
-    "uan": "Enter a unique application number (UAN)"
+    "required": "Enter a unique application number (UAN)",
+    "uan": "Enter a valid unique application number (UAN)"
   },
   "representative-first-names": {
     "required": {

--- a/test/ui/04 - applicant-details/content.spec.js
+++ b/test/ui/04 - applicant-details/content.spec.js
@@ -102,7 +102,7 @@ describe('/applicant-details - content', () => {
           expect(textInputs.length).to.equal(3);
           expect(labels.length).to.equal(3);
 
-          expect((await labels[2].innerText()).includes('Unique application number - UAN (optional)')).to.equal(true);
+          expect((await labels[2].innerText()).includes('Unique application number - UAN')).to.equal(true);
           expect((await labels[2].innerText()).includes('For example, 3434-0000-0000-0001')).to.equal(true);
         });
 
@@ -164,7 +164,7 @@ describe('/applicant-details - content', () => {
           expect(textInputs.length).to.equal(3);
           expect(labels.length).to.equal(3);
 
-          expect((await labels[2].innerText()).includes('Unique application number - UAN (optional)')).to.equal(true);
+          expect((await labels[2].innerText()).includes('Unique application number - UAN')).to.equal(true);
           expect((await labels[2].innerText()).includes('For example, 3434-0000-0000-0001')).to.equal(true);
         });
 

--- a/test/ui/04 - applicant-details/validation.spec.js
+++ b/test/ui/04 - applicant-details/validation.spec.js
@@ -150,7 +150,7 @@ describe('/applicant-details - validation', () => {
 
         });
 
-        describe('when user submits the page with a URL in the \'first names\' field', () => {
+        describe('when user submits the page with a URL in the \'First names\' field', () => {
 
           it('should display an error message with text \'Enter the applicant\'s first names\'', async() => {
             await page.fill('#applicant-first-names', 'www.test.com');
@@ -169,7 +169,7 @@ describe('/applicant-details - validation', () => {
 
         });
 
-        describe('when user submits the page with a URL in the \'last names\' field', () => {
+        describe('when user submits the page with a URL in the \'Last names\' field', () => {
 
           it('should display an error message with text \'Enter the applicant\'s last names\'', async() => {
             await page.fill('#applicant-first-names', config.validFirstNames);
@@ -236,7 +236,7 @@ describe('/applicant-details - validation', () => {
 
         });
 
-        describe('when user submits the page with a URL in the \'given names\' field', () => {
+        describe('when user submits the page with a URL in the \'Given names\' field', () => {
 
           it('should display an error message with text \'Enter your given names\'', async() => {
             await page.fill('#applicant-first-names', 'www.test.com');
@@ -255,7 +255,7 @@ describe('/applicant-details - validation', () => {
 
         });
 
-        describe('when user submits the page with a URL in the \'family names\' field', () => {
+        describe('when user submits the page with a URL in the \'Family names\' field', () => {
 
           it('should display an error message with text \'Enter your family names\'', async() => {
             await page.fill('#applicant-first-names', config.validFirstNames);
@@ -368,14 +368,20 @@ describe('/applicant-details - validation', () => {
 
     describe('when user submits the page without entering a UAN', () => {
 
-      it('should not show an error', async() => {
+      it('should display an error message with text \'Enter a unique application number (UAN)\'', async() => {
         // populate other fields with valid inputs
         await page.fill('#applicant-first-names', config.validFirstNames);
         await page.fill('#applicant-last-names', config.validLastNames);
 
         await submitPage();
 
-        expect(await page.url()).to.equal(baseURL + '/contact-details');
+        const errorSummaries = await getErrorSummaries();
+        const errorMessages = await getErrorMessages();
+
+        expect(errorSummaries.length).to.equal(1);
+        expect(errorMessages.length).to.equal(1);
+        expect(await errorSummaries[0].innerText()).to.equal('Enter a unique application number (UAN)');
+        expect(await errorMessages[0].innerText()).to.equal('Enter a unique application number (UAN)');
       });
 
     });
@@ -396,8 +402,8 @@ describe('/applicant-details - validation', () => {
 
         expect(errorSummaries.length).to.equal(1);
         expect(errorMessages.length).to.equal(1);
-        expect(await errorSummaries[0].innerText()).to.equal('Enter a unique application number (UAN)');
-        expect(await errorMessages[0].innerText()).to.equal('Enter a unique application number (UAN)');
+        expect(await errorSummaries[0].innerText()).to.equal('Enter a valid unique application number (UAN)');
+        expect(await errorMessages[0].innerText()).to.equal('Enter a valid unique application number (UAN)');
       });
 
     });

--- a/test/ui/08 - confirm/confirm.spec.js
+++ b/test/ui/08 - confirm/confirm.spec.js
@@ -23,7 +23,7 @@ const setUp = async(inUK, question, identity, useOptionalFields, shouldSucceed) 
   // fill applicant details
   await page.fill('#applicant-first-names', config.validFirstNames);
   await page.fill('#applicant-last-names', config.validLastNames);
-  if (useOptionalFields && question !== 'id-check') {
+  if (question !== 'id-check') {
     await page.fill('#application-number', config.validUAN);
   }
   await submitPage();
@@ -97,26 +97,28 @@ describe('/confirm', () => {
         const labels = await page.$$('.confirm-label');
         const values = await page.$$('.confirm-value');
 
-        expect(labels.length).to.equal(8);
-        expect(values.length).to.equal(8);
+        expect(labels.length).to.equal(9);
+        expect(values.length).to.equal(9);
 
         expect(await labels[0].innerText()).to.equal('What is your problem about?');
         expect(await labels[1].innerText()).to.equal('Are you contacting us on behalf of someone else?');
         expect(await labels[2].innerText()).to.equal('First names');
         expect(await labels[3].innerText()).to.equal('Last names');
-        expect(await labels[4].innerText()).to.equal('First names');
-        expect(await labels[5].innerText()).to.equal('Last names');
-        expect(await labels[6].innerText()).to.equal('Email address');
-        expect(await labels[7].innerText()).to.equal('Details of the problem');
+        expect(await labels[4].innerText()).to.equal('Unique application number - UAN');
+        expect(await labels[5].innerText()).to.equal('First names');
+        expect(await labels[6].innerText()).to.equal('Last names');
+        expect(await labels[7].innerText()).to.equal('Email address');
+        expect(await labels[8].innerText()).to.equal('Details of the problem');
 
         expect(await values[0].innerText()).to.equal('Viewing or proving your immigration status, right to work or right to rent');
         expect(await values[1].innerText()).to.equal('Yes');
         expect(await values[2].innerText()).to.equal(config.validFirstNames);
         expect(await values[3].innerText()).to.equal(config.validLastNames);
-        expect(await values[4].innerText()).to.equal(config.validFirstNames);
-        expect(await values[5].innerText()).to.equal(config.validLastNames);
-        expect(await values[6].innerText()).to.equal(config.validEmail);
-        expect(await values[7].innerText()).to.equal(config.validQuery);
+        expect(await values[4].innerText()).to.equal(config.validUAN);
+        expect(await values[5].innerText()).to.equal(config.validFirstNames);
+        expect(await values[6].innerText()).to.equal(config.validLastNames);
+        expect(await values[7].innerText()).to.equal(config.validEmail);
+        expect(await values[8].innerText()).to.equal(config.validQuery);
       });
 
     });
@@ -230,7 +232,7 @@ describe('/confirm', () => {
         // check the update value is now on the confirm page
         expect(await page.url()).to.equal(baseURL + '/confirm#query');
         const values = await page.$$('.confirm-value');
-        expect(await values[5].innerText()).to.equal(updatedValue);
+        expect(await values[6].innerText()).to.equal(updatedValue);
       });
 
     });
@@ -330,6 +332,26 @@ describe('/confirm', () => {
         expect(await fields[4].innerText()).to.not.equal('Unique application number - UAN');
         expect(await fields[5].innerText()).to.not.equal('Unique application number - UAN');
         expect(await fields[6].innerText()).to.not.equal('Unique application number - UAN');
+      });
+
+    });
+
+    describe('when the user changes their question category from \'id check\' to \'status\'', () => {
+
+      beforeEach(async() => await setUp(true, 'id-check', 'No', true, true));
+
+      it('should collect the UAN field on the applicant details page', async() => {
+        // find and click question link
+        const questionLink = await page.$('a[href="/question/edit#question-id-check"]');
+        await questionLink.click();
+        await page.waitForLoadState();
+
+        // select status
+        const idCheckRadio = await page.$('#question-status');
+        await idCheckRadio.click();
+        await submitPage();
+
+        expect(await page.url()).to.equal(baseURL + '/applicant-details/edit#question-id-check');
       });
 
     });

--- a/test/unit/behaviours/add-uan-validator-if-required.spec.js
+++ b/test/unit/behaviours/add-uan-validator-if-required.spec.js
@@ -38,16 +38,16 @@ describe('Add UAN validator if required behaviour', () => {
       testInstance = new AddUANValidatorIfRequired();
     });
 
-    it('should add the uan validator to application number if question is status', () => {
+    it('should add the uan and required validators to application number if question is status', () => {
       req.sessionModel.get.returns('status');
       testInstance.process(req, res, () => {});
-      expect(req.form.options.fields['application-number'].validate).to.deep.equal([uanValidator]);
+      expect(req.form.options.fields['application-number'].validate).to.deep.equal([uanValidator, 'required']);
     });
 
     it('should add the uan validator to application number if question is account', () => {
       req.sessionModel.get.returns('account');
       testInstance.process(req, res, () => {});
-      expect(req.form.options.fields['application-number'].validate).to.deep.equal([uanValidator]);
+      expect(req.form.options.fields['application-number'].validate).to.deep.equal([uanValidator, 'required']);
     });
 
     it('should not add the uan validator to application number if question is id-check', () => {

--- a/test/unit/behaviours/handle-identity-change.spec.js
+++ b/test/unit/behaviours/handle-identity-change.spec.js
@@ -110,7 +110,7 @@ describe('Handle identity change behaviour', () => {
 
         expect(req.sessionModel.set.callCount).to.equal(1);
         expect(req.sessionModel.set.firstCall.args).to.deep.equal(['identity', 'Yes']);
-        expect(res.redirect).to.have.been.calledOnceWith('www.baseUrl.co.uk/representative-details/edit');
+        expect(res.redirect).to.have.been.calledOnceWith('/representative-details/edit');
       });
 
     });

--- a/test/unit/behaviours/handle-question-change.spec.js
+++ b/test/unit/behaviours/handle-question-change.spec.js
@@ -21,6 +21,10 @@ describe('Handle question change behaviour', () => {
         values: {}
       }
     };
+
+    res = {
+      redirect: sinon.stub()
+    };
   });
 
   describe('saveValues', () => {
@@ -112,6 +116,22 @@ describe('Handle question change behaviour', () => {
           expect(req.sessionModel.set.notCalled).to.equal(true);
         });
 
+      });
+
+    });
+
+    describe('when user submits using the change link, new question is status, and previous question is id-check', () => {
+
+      it('should set the new question on the session and redirect to the applicant details page', () => {
+        req.url = '/question/edit';
+        req.form.values.question = 'status';
+        req.sessionModel.get.withArgs('question').returns('id-check');
+
+        testInstance.saveValues(req, res, () => {});
+
+        expect(req.sessionModel.set.callCount).to.equal(1);
+        expect(req.sessionModel.set.firstCall.args).to.deep.equal(['question', 'status']);
+        expect(res.redirect).to.have.been.calledOnceWith('/applicant-details/edit');
       });
 
     });


### PR DESCRIPTION
### What
Adds 'required' validator to UAN when required.
Collects UAN when question category is changed
Removes back link from details pages after question category or identity is changed
