### PR TITLE
FBISCC-159: add hint text to fields on contact details page

### DIFF
--- a/apps/fbis-ccf/translations/src/en/fields.json
+++ b/apps/fbis-ccf/translations/src/en/fields.json
@@ -67,11 +67,12 @@
     "label": "Organisation name (optional)"
   },
   "email": {
-    "label": "Email address"
+    "label": "Applicant's email address",
+    "hint": "This is where we'll send our reply. Make sure this is the same email address used for the application"
   },
   "phone": {
-    "label": "Phone number (optional)",
-    "hint": "Include the country code if this is not a UK number"
+    "label": "Telephone number (optional)",
+    "hint": "We may want to contact you by telephone if we need more information to answer your question. Include the country code if this is not a UK number"
   },
   "query": {
     "label": "Give a detailed description of the problem",

--- a/test/ui/06 - contact-details/contact-details.spec.js
+++ b/test/ui/06 - contact-details/contact-details.spec.js
@@ -42,7 +42,8 @@ describe('/contact-details', () => {
       expect(textInputs.length).to.equal(2);
       expect(labels.length).to.equal(2);
 
-      expect(await labels[0].innerText()).to.equal('Email address');
+      expect(await labels[0].innerText()).to.include('Applicant\'s email address');
+      expect(await labels[0].innerText()).to.include('This is where we\'ll send our reply. Make sure this is the same email address used for the application');
     });
 
     it('should include a text input field for phone', async() => {
@@ -52,8 +53,8 @@ describe('/contact-details', () => {
       expect(textInputs.length).to.equal(2);
       expect(labels.length).to.equal(2);
 
-      expect((await labels[1].innerText()).includes('Phone number (optional)')).to.equal(true);
-      expect((await labels[1].innerText()).includes('Include the country code if this is not a UK number')).to.equal(true);
+      expect((await labels[1].innerText()).includes('Telephone number (optional)')).to.equal(true);
+      expect((await labels[1].innerText()).includes('We may want to contact you by telephone if we need more information to answer your question. Include the country code if this is not a UK number')).to.equal(true);
     });
 
   });


### PR DESCRIPTION
### What
Edit hint text on contact details fields to match new design
Update tests
